### PR TITLE
PageHeader 추가

### DIFF
--- a/src/app/routeTree.gen.ts
+++ b/src/app/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as AboutImport } from './routes/about'
 import { Route as IndexImport } from './routes/index'
 import { Route as ComponentTextInputImport } from './routes/component/text-input'
 import { Route as ComponentTextAreaImport } from './routes/component/text-area'
+import { Route as ComponentPageHeaderImport } from './routes/component/page-header'
 import { Route as ComponentCalendarDrawerImport } from './routes/component/calendar-drawer'
 import { Route as ComponentButtonsTestImport } from './routes/component/buttons-test'
 
@@ -48,6 +49,12 @@ const ComponentTextInputRoute = ComponentTextInputImport.update({
 const ComponentTextAreaRoute = ComponentTextAreaImport.update({
   id: '/component/text-area',
   path: '/component/text-area',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const ComponentPageHeaderRoute = ComponentPageHeaderImport.update({
+  id: '/component/page-header',
+  path: '/component/page-header',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -102,6 +109,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ComponentCalendarDrawerImport
       parentRoute: typeof rootRoute
     }
+    '/component/page-header': {
+      id: '/component/page-header'
+      path: '/component/page-header'
+      fullPath: '/component/page-header'
+      preLoaderRoute: typeof ComponentPageHeaderImport
+      parentRoute: typeof rootRoute
+    }
     '/component/text-area': {
       id: '/component/text-area'
       path: '/component/text-area'
@@ -127,6 +141,7 @@ export interface FileRoutesByFullPath {
   '/expenses': typeof ExpensesRoute
   '/component/buttons-test': typeof ComponentButtonsTestRoute
   '/component/calendar-drawer': typeof ComponentCalendarDrawerRoute
+  '/component/page-header': typeof ComponentPageHeaderRoute
   '/component/text-area': typeof ComponentTextAreaRoute
   '/component/text-input': typeof ComponentTextInputRoute
 }
@@ -137,6 +152,7 @@ export interface FileRoutesByTo {
   '/expenses': typeof ExpensesRoute
   '/component/buttons-test': typeof ComponentButtonsTestRoute
   '/component/calendar-drawer': typeof ComponentCalendarDrawerRoute
+  '/component/page-header': typeof ComponentPageHeaderRoute
   '/component/text-area': typeof ComponentTextAreaRoute
   '/component/text-input': typeof ComponentTextInputRoute
 }
@@ -148,6 +164,7 @@ export interface FileRoutesById {
   '/expenses': typeof ExpensesRoute
   '/component/buttons-test': typeof ComponentButtonsTestRoute
   '/component/calendar-drawer': typeof ComponentCalendarDrawerRoute
+  '/component/page-header': typeof ComponentPageHeaderRoute
   '/component/text-area': typeof ComponentTextAreaRoute
   '/component/text-input': typeof ComponentTextInputRoute
 }
@@ -160,6 +177,7 @@ export interface FileRouteTypes {
     | '/expenses'
     | '/component/buttons-test'
     | '/component/calendar-drawer'
+    | '/component/page-header'
     | '/component/text-area'
     | '/component/text-input'
   fileRoutesByTo: FileRoutesByTo
@@ -169,6 +187,7 @@ export interface FileRouteTypes {
     | '/expenses'
     | '/component/buttons-test'
     | '/component/calendar-drawer'
+    | '/component/page-header'
     | '/component/text-area'
     | '/component/text-input'
   id:
@@ -178,6 +197,7 @@ export interface FileRouteTypes {
     | '/expenses'
     | '/component/buttons-test'
     | '/component/calendar-drawer'
+    | '/component/page-header'
     | '/component/text-area'
     | '/component/text-input'
   fileRoutesById: FileRoutesById
@@ -189,6 +209,7 @@ export interface RootRouteChildren {
   ExpensesRoute: typeof ExpensesRoute
   ComponentButtonsTestRoute: typeof ComponentButtonsTestRoute
   ComponentCalendarDrawerRoute: typeof ComponentCalendarDrawerRoute
+  ComponentPageHeaderRoute: typeof ComponentPageHeaderRoute
   ComponentTextAreaRoute: typeof ComponentTextAreaRoute
   ComponentTextInputRoute: typeof ComponentTextInputRoute
 }
@@ -199,6 +220,7 @@ const rootRouteChildren: RootRouteChildren = {
   ExpensesRoute: ExpensesRoute,
   ComponentButtonsTestRoute: ComponentButtonsTestRoute,
   ComponentCalendarDrawerRoute: ComponentCalendarDrawerRoute,
+  ComponentPageHeaderRoute: ComponentPageHeaderRoute,
   ComponentTextAreaRoute: ComponentTextAreaRoute,
   ComponentTextInputRoute: ComponentTextInputRoute,
 }
@@ -218,6 +240,7 @@ export const routeTree = rootRoute
         "/expenses",
         "/component/buttons-test",
         "/component/calendar-drawer",
+        "/component/page-header",
         "/component/text-area",
         "/component/text-input"
       ]
@@ -236,6 +259,9 @@ export const routeTree = rootRoute
     },
     "/component/calendar-drawer": {
       "filePath": "component/calendar-drawer.tsx"
+    },
+    "/component/page-header": {
+      "filePath": "component/page-header.tsx"
     },
     "/component/text-area": {
       "filePath": "component/text-area.tsx"

--- a/src/app/routes/component/page-header.tsx
+++ b/src/app/routes/component/page-header.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import Layout from '@/shared/ui/layout/Layout';
+import PageHeader from '@/shared/ui/PageHeader';
+import SubPageHeader from '@/shared/ui/SubPageHeader';
+
+export const Route = createFileRoute('/component/page-header')({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return (
+    <Layout>
+      <PageHeader />
+      <SubPageHeader backLink='tt' title='very long title' />
+    </Layout>
+  );
+}

--- a/src/shared/ui/PageHeader/PageHeader.test.tsx
+++ b/src/shared/ui/PageHeader/PageHeader.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it } from 'vitest';
+import { render } from '@testing-library/react';
+
+import PageHeader from './PageHeader';
+
+describe('PageHeader', () => {
+  it('renders Logo.', () => {
+    const { getByLabelText } = render(<PageHeader />);
+    const logo = getByLabelText('로고');
+
+    expect(logo).toBeInTheDocument();
+  });
+
+  it('renders Setting Button.', () => {
+    const { getByLabelText } = render(<PageHeader />);
+    const settingButton = getByLabelText('세팅 버튼');
+
+    expect(settingButton).toBeInTheDocument();
+  });
+});

--- a/src/shared/ui/PageHeader/PageHeader.tsx
+++ b/src/shared/ui/PageHeader/PageHeader.tsx
@@ -1,0 +1,18 @@
+import { Settings } from 'lucide-react';
+
+import Logo from '@/shared/ui/icons/Logo';
+
+const PageHeader: React.FC = () => {
+  return (
+    <header className='flex flex-row h-14 px-5 py-4'>
+      <div aria-label='로고'>
+        <Logo />
+      </div>
+      <div aria-label='세팅 버튼' role='button' className='ml-auto'>
+        <Settings size='24' />
+      </div>
+    </header>
+  );
+};
+
+export default PageHeader;

--- a/src/shared/ui/PageHeader/index.tsx
+++ b/src/shared/ui/PageHeader/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './PageHeader';

--- a/src/shared/ui/SubPageHeader/SubPageHeader.tsx
+++ b/src/shared/ui/SubPageHeader/SubPageHeader.tsx
@@ -8,7 +8,7 @@ export interface SubPageHeaderProps {
 const SubPageHeader: React.FC<SubPageHeaderProps> = ({ backLink, title }) => {
   return (
     <header className='flex flex-row h-12 px-4 py-3'>
-      <Link className='w-6 h-6' aria-label='뒤로가기' to={backLink}>
+      <Link aria-label='뒤로가기' to={backLink} role='button'>
         <svg
           xmlns='http://www.w3.org/2000/svg'
           width='24'


### PR DESCRIPTION
- #46 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 새로운 페이지 헤더 라우트가 추가되어, 헤더와 서브 헤더가 포함된 레이아웃을 제공합니다.
	- 로고와 설정 버튼을 갖춘 헤더 컴포넌트가 도입되어 페이지 상단의 디자인이 개선되었습니다.
  
- **테스트**
	- 헤더 컴포넌트 요소(로고, 설정 버튼)의 렌더링을 검증하는 테스트가 추가되었습니다.
  
- **스타일**
	- 서브 페이지 헤더 내 링크의 접근성이 향상되어 버튼 역할이 명확하게 지정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->