### PR TITLE
ExpenseForm을 shadcn/ui form을 사용하도록 업데이트 및 expenses.new 페이지 구현

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=https://api.blink-it.me

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,7 +13,7 @@ import tseslint from 'typescript-eslint';
 import eslintConfigPrettier from 'eslint-config-prettier';
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', './src/app/routeTree.gen.ts'] },
   {
     extends: [
       js.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-day-picker": "8.10.1",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.55.0",
+    "react-number-format": "^5.4.3",
     "sonner": "^2.0.1",
     "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.0.1",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-slot": "^1.1.2",
@@ -30,10 +31,12 @@
     "react": "^19.0.0",
     "react-day-picker": "8.10.1",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.55.0",
     "sonner": "^2.0.1",
     "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
+    "zod": "^3.24.2",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "dompurify": "^3.2.4",
     "lucide-react": "^0.479.0",
     "nanoid": "^5.1.5",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dompurify:
+        specifier: ^3.2.4
+        version: 3.2.4
       lucide-react:
         specifier: ^0.479.0
         version: 0.479.0(react@19.0.0)
@@ -1233,6 +1236,9 @@ packages:
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@typescript-eslint/eslint-plugin@8.26.0':
     resolution: {integrity: sha512-cLr1J6pe56zjKYajK6SSSre6nl1Gj6xDp1TY0trpgPzjVbgDwd09v2Ws37LABxzkicmUjhEeg/fAUjPJJB1v5Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1569,6 +1575,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.2.4:
+    resolution: {integrity: sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3790,6 +3799,9 @@ snapshots:
   '@types/tough-cookie@4.0.5':
     optional: true
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -4166,6 +4178,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.2.4:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dunder-proto@1.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       react-hook-form:
         specifier: ^7.55.0
         version: 7.55.0(react@19.0.0)
+      react-number-format:
+        specifier: ^5.4.3
+        version: 5.4.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       sonner:
         specifier: ^2.0.1
         version: 2.0.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -2301,6 +2304,12 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-number-format@5.4.3:
+    resolution: {integrity: sha512-VCY5hFg/soBighAoGcdE+GagkJq0230qN6jcS5sp8wQX1qy1fYN/RX7/BXkrs0oyzzwqR8/+eSUrqXbGeywdUQ==}
+    peerDependencies:
+      react: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -4878,6 +4887,11 @@ snapshots:
       react: 19.0.0
 
   react-is@17.0.2: {}
+
+  react-number-format@5.4.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   react-remove-scroll-bar@2.3.8(@types/react@19.0.10)(react@19.0.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.0.1
+        version: 5.0.1(react-hook-form@7.55.0(react@19.0.0))
       '@radix-ui/react-dialog':
         specifier: ^1.1.6
         version: 1.1.6(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -56,6 +59,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
+      react-hook-form:
+        specifier: ^7.55.0
+        version: 7.55.0(react@19.0.0)
       sonner:
         specifier: ^2.0.1
         version: 2.0.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -68,6 +74,9 @@ importers:
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
       zustand:
         specifier: ^5.0.3
         version: 5.0.3(@types/react@19.0.10)(react@19.0.0)(use-sync-external-store@1.4.0(react@19.0.0))
@@ -498,6 +507,11 @@ packages:
     resolution: {integrity: sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@hookform/resolvers@5.0.1':
+    resolution: {integrity: sha512-u/+Jp83luQNx9AdyW2fIPGY6Y7NG68eN2ZW8FOJYL+M0i4s49+refdJdOp/A9n9HFQtQs3HIDHQvX3ZET2o7YA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -885,6 +899,9 @@ packages:
     resolution: {integrity: sha512-AyleYRPU7+rgkMWbEh71fQlrzRfeP6SyMnRf9XX4fCdDPAJumdSBqYEcWPMzVQ4ScAl7E4oFfK0GUVn77xSwbw==}
     cpu: [x64]
     os: [win32]
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/core-darwin-arm64@1.11.5':
     resolution: {integrity: sha512-GEd1hzEx0mSGkJYMFMGLnrGgjL2rOsOsuYWyjyiA3WLmhD7o+n/EWBDo6mzD/9aeF8dzSPC0TnW216gJbvrNzA==}
@@ -2276,6 +2293,12 @@ packages:
     peerDependencies:
       react: ^19.0.0
 
+  react-hook-form@7.55.0:
+    resolution: {integrity: sha512-XRnjsH3GVMQz1moZTW53MxfoWN7aDpUg/GpVNc4A3eXRVNdGXfbzJ4vM4aLQ8g6XCUh1nIbx70aaNCl7kxnjog==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
@@ -3122,6 +3145,11 @@ snapshots:
       '@eslint/core': 0.12.0
       levn: 0.4.1
 
+  '@hookform/resolvers@5.0.1(react-hook-form@7.55.0(react@19.0.0))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.55.0(react@19.0.0)
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -3439,6 +3467,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.34.9':
     optional: true
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/core-darwin-arm64@1.11.5':
     optional: true
@@ -4842,6 +4872,10 @@ snapshots:
     dependencies:
       react: 19.0.0
       scheduler: 0.25.0
+
+  react-hook-form@7.55.0(react@19.0.0):
+    dependencies:
+      react: 19.0.0
 
   react-is@17.0.2: {}
 

--- a/src/app/routeTree.gen.ts
+++ b/src/app/routeTree.gen.ts
@@ -10,21 +10,21 @@
 
 // Import Routes
 
-import { Route as rootRoute } from './routes/__root';
-import { Route as IndexImport } from './routes/index';
-import { Route as ExpensesIndexImport } from './routes/expenses.index';
-import { Route as ExpensesNewImport } from './routes/expenses.new';
-import { Route as ComponentUnderlinedTextInputImport } from './routes/component/underlined-text-input';
-import { Route as ComponentToasterImport } from './routes/component/toaster';
-import { Route as ComponentTextInputImport } from './routes/component/text-input';
-import { Route as ComponentTextAreaImport } from './routes/component/text-area';
-import { Route as ComponentSubPageHeaderImport } from './routes/component/sub-page-header';
-import { Route as ComponentSelectMonthDrawerImport } from './routes/component/select-month-drawer';
-import { Route as ComponentInputCategoryTagsImport } from './routes/component/input-category-tags';
-import { Route as ComponentIconTestImport } from './routes/component/icon-test';
-import { Route as ComponentCategoryTagsImport } from './routes/component/category-tags';
-import { Route as ComponentCalendarDrawerImport } from './routes/component/calendar-drawer';
-import { Route as ComponentButtonsTestImport } from './routes/component/buttons-test';
+import { Route as rootRoute } from './routes/__root'
+import { Route as IndexImport } from './routes/index'
+import { Route as ExpensesIndexImport } from './routes/expenses.index'
+import { Route as ExpensesNewImport } from './routes/expenses.new'
+import { Route as ComponentUnderlinedTextInputImport } from './routes/component/underlined-text-input'
+import { Route as ComponentToasterImport } from './routes/component/toaster'
+import { Route as ComponentTextInputImport } from './routes/component/text-input'
+import { Route as ComponentTextAreaImport } from './routes/component/text-area'
+import { Route as ComponentSubPageHeaderImport } from './routes/component/sub-page-header'
+import { Route as ComponentSelectMonthDrawerImport } from './routes/component/select-month-drawer'
+import { Route as ComponentInputCategoryTagsImport } from './routes/component/input-category-tags'
+import { Route as ComponentIconTestImport } from './routes/component/icon-test'
+import { Route as ComponentCategoryTagsImport } from './routes/component/category-tags'
+import { Route as ComponentCalendarDrawerImport } from './routes/component/calendar-drawer'
+import { Route as ComponentButtonsTestImport } from './routes/component/buttons-test'
 
 // Create/Update Routes
 
@@ -32,252 +32,252 @@ const IndexRoute = IndexImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const ExpensesIndexRoute = ExpensesIndexImport.update({
   id: '/expenses/',
   path: '/expenses/',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const ExpensesNewRoute = ExpensesNewImport.update({
   id: '/expenses/new',
   path: '/expenses/new',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const ComponentUnderlinedTextInputRoute =
   ComponentUnderlinedTextInputImport.update({
     id: '/component/underlined-text-input',
     path: '/component/underlined-text-input',
     getParentRoute: () => rootRoute,
-  } as any);
+  } as any)
 
 const ComponentToasterRoute = ComponentToasterImport.update({
   id: '/component/toaster',
   path: '/component/toaster',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const ComponentTextInputRoute = ComponentTextInputImport.update({
   id: '/component/text-input',
   path: '/component/text-input',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const ComponentTextAreaRoute = ComponentTextAreaImport.update({
   id: '/component/text-area',
   path: '/component/text-area',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const ComponentSubPageHeaderRoute = ComponentSubPageHeaderImport.update({
   id: '/component/sub-page-header',
   path: '/component/sub-page-header',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const ComponentSelectMonthDrawerRoute = ComponentSelectMonthDrawerImport.update(
   {
     id: '/component/select-month-drawer',
     path: '/component/select-month-drawer',
     getParentRoute: () => rootRoute,
-  } as any
-);
+  } as any,
+)
 
 const ComponentInputCategoryTagsRoute = ComponentInputCategoryTagsImport.update(
   {
     id: '/component/input-category-tags',
     path: '/component/input-category-tags',
     getParentRoute: () => rootRoute,
-  } as any
-);
+  } as any,
+)
 
 const ComponentIconTestRoute = ComponentIconTestImport.update({
   id: '/component/icon-test',
   path: '/component/icon-test',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const ComponentCategoryTagsRoute = ComponentCategoryTagsImport.update({
   id: '/component/category-tags',
   path: '/component/category-tags',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const ComponentCalendarDrawerRoute = ComponentCalendarDrawerImport.update({
   id: '/component/calendar-drawer',
   path: '/component/calendar-drawer',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const ComponentButtonsTestRoute = ComponentButtonsTestImport.update({
   id: '/component/buttons-test',
   path: '/component/buttons-test',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 // Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
     '/': {
-      id: '/';
-      path: '/';
-      fullPath: '/';
-      preLoaderRoute: typeof IndexImport;
-      parentRoute: typeof rootRoute;
-    };
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexImport
+      parentRoute: typeof rootRoute
+    }
     '/component/buttons-test': {
-      id: '/component/buttons-test';
-      path: '/component/buttons-test';
-      fullPath: '/component/buttons-test';
-      preLoaderRoute: typeof ComponentButtonsTestImport;
-      parentRoute: typeof rootRoute;
-    };
+      id: '/component/buttons-test'
+      path: '/component/buttons-test'
+      fullPath: '/component/buttons-test'
+      preLoaderRoute: typeof ComponentButtonsTestImport
+      parentRoute: typeof rootRoute
+    }
     '/component/calendar-drawer': {
-      id: '/component/calendar-drawer';
-      path: '/component/calendar-drawer';
-      fullPath: '/component/calendar-drawer';
-      preLoaderRoute: typeof ComponentCalendarDrawerImport;
-      parentRoute: typeof rootRoute;
-    };
+      id: '/component/calendar-drawer'
+      path: '/component/calendar-drawer'
+      fullPath: '/component/calendar-drawer'
+      preLoaderRoute: typeof ComponentCalendarDrawerImport
+      parentRoute: typeof rootRoute
+    }
     '/component/category-tags': {
-      id: '/component/category-tags';
-      path: '/component/category-tags';
-      fullPath: '/component/category-tags';
-      preLoaderRoute: typeof ComponentCategoryTagsImport;
-      parentRoute: typeof rootRoute;
-    };
+      id: '/component/category-tags'
+      path: '/component/category-tags'
+      fullPath: '/component/category-tags'
+      preLoaderRoute: typeof ComponentCategoryTagsImport
+      parentRoute: typeof rootRoute
+    }
     '/component/icon-test': {
-      id: '/component/icon-test';
-      path: '/component/icon-test';
-      fullPath: '/component/icon-test';
-      preLoaderRoute: typeof ComponentIconTestImport;
-      parentRoute: typeof rootRoute;
-    };
+      id: '/component/icon-test'
+      path: '/component/icon-test'
+      fullPath: '/component/icon-test'
+      preLoaderRoute: typeof ComponentIconTestImport
+      parentRoute: typeof rootRoute
+    }
     '/component/input-category-tags': {
-      id: '/component/input-category-tags';
-      path: '/component/input-category-tags';
-      fullPath: '/component/input-category-tags';
-      preLoaderRoute: typeof ComponentInputCategoryTagsImport;
-      parentRoute: typeof rootRoute;
-    };
+      id: '/component/input-category-tags'
+      path: '/component/input-category-tags'
+      fullPath: '/component/input-category-tags'
+      preLoaderRoute: typeof ComponentInputCategoryTagsImport
+      parentRoute: typeof rootRoute
+    }
     '/component/select-month-drawer': {
-      id: '/component/select-month-drawer';
-      path: '/component/select-month-drawer';
-      fullPath: '/component/select-month-drawer';
-      preLoaderRoute: typeof ComponentSelectMonthDrawerImport;
-      parentRoute: typeof rootRoute;
-    };
+      id: '/component/select-month-drawer'
+      path: '/component/select-month-drawer'
+      fullPath: '/component/select-month-drawer'
+      preLoaderRoute: typeof ComponentSelectMonthDrawerImport
+      parentRoute: typeof rootRoute
+    }
     '/component/sub-page-header': {
-      id: '/component/sub-page-header';
-      path: '/component/sub-page-header';
-      fullPath: '/component/sub-page-header';
-      preLoaderRoute: typeof ComponentSubPageHeaderImport;
-      parentRoute: typeof rootRoute;
-    };
+      id: '/component/sub-page-header'
+      path: '/component/sub-page-header'
+      fullPath: '/component/sub-page-header'
+      preLoaderRoute: typeof ComponentSubPageHeaderImport
+      parentRoute: typeof rootRoute
+    }
     '/component/text-area': {
-      id: '/component/text-area';
-      path: '/component/text-area';
-      fullPath: '/component/text-area';
-      preLoaderRoute: typeof ComponentTextAreaImport;
-      parentRoute: typeof rootRoute;
-    };
+      id: '/component/text-area'
+      path: '/component/text-area'
+      fullPath: '/component/text-area'
+      preLoaderRoute: typeof ComponentTextAreaImport
+      parentRoute: typeof rootRoute
+    }
     '/component/text-input': {
-      id: '/component/text-input';
-      path: '/component/text-input';
-      fullPath: '/component/text-input';
-      preLoaderRoute: typeof ComponentTextInputImport;
-      parentRoute: typeof rootRoute;
-    };
+      id: '/component/text-input'
+      path: '/component/text-input'
+      fullPath: '/component/text-input'
+      preLoaderRoute: typeof ComponentTextInputImport
+      parentRoute: typeof rootRoute
+    }
     '/component/toaster': {
-      id: '/component/toaster';
-      path: '/component/toaster';
-      fullPath: '/component/toaster';
-      preLoaderRoute: typeof ComponentToasterImport;
-      parentRoute: typeof rootRoute;
-    };
+      id: '/component/toaster'
+      path: '/component/toaster'
+      fullPath: '/component/toaster'
+      preLoaderRoute: typeof ComponentToasterImport
+      parentRoute: typeof rootRoute
+    }
     '/component/underlined-text-input': {
-      id: '/component/underlined-text-input';
-      path: '/component/underlined-text-input';
-      fullPath: '/component/underlined-text-input';
-      preLoaderRoute: typeof ComponentUnderlinedTextInputImport;
-      parentRoute: typeof rootRoute;
-    };
+      id: '/component/underlined-text-input'
+      path: '/component/underlined-text-input'
+      fullPath: '/component/underlined-text-input'
+      preLoaderRoute: typeof ComponentUnderlinedTextInputImport
+      parentRoute: typeof rootRoute
+    }
     '/expenses/new': {
-      id: '/expenses/new';
-      path: '/expenses/new';
-      fullPath: '/expenses/new';
-      preLoaderRoute: typeof ExpensesNewImport;
-      parentRoute: typeof rootRoute;
-    };
+      id: '/expenses/new'
+      path: '/expenses/new'
+      fullPath: '/expenses/new'
+      preLoaderRoute: typeof ExpensesNewImport
+      parentRoute: typeof rootRoute
+    }
     '/expenses/': {
-      id: '/expenses/';
-      path: '/expenses/';
-      fullPath: '/expenses/';
-      preLoaderRoute: typeof ExpensesIndexImport;
-      parentRoute: typeof rootRoute;
-    };
+      id: '/expenses/'
+      path: '/expenses'
+      fullPath: '/expenses'
+      preLoaderRoute: typeof ExpensesIndexImport
+      parentRoute: typeof rootRoute
+    }
   }
 }
 
 // Create and export the route tree
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute;
-  '/component/buttons-test': typeof ComponentButtonsTestRoute;
-  '/component/calendar-drawer': typeof ComponentCalendarDrawerRoute;
-  '/component/category-tags': typeof ComponentCategoryTagsRoute;
-  '/component/icon-test': typeof ComponentIconTestRoute;
-  '/component/input-category-tags': typeof ComponentInputCategoryTagsRoute;
-  '/component/select-month-drawer': typeof ComponentSelectMonthDrawerRoute;
-  '/component/sub-page-header': typeof ComponentSubPageHeaderRoute;
-  '/component/text-area': typeof ComponentTextAreaRoute;
-  '/component/text-input': typeof ComponentTextInputRoute;
-  '/component/toaster': typeof ComponentToasterRoute;
-  '/component/underlined-text-input': typeof ComponentUnderlinedTextInputRoute;
-  '/expenses/new': typeof ExpensesNewRoute;
-  '/expenses/': typeof ExpensesIndexRoute;
+  '/': typeof IndexRoute
+  '/component/buttons-test': typeof ComponentButtonsTestRoute
+  '/component/calendar-drawer': typeof ComponentCalendarDrawerRoute
+  '/component/category-tags': typeof ComponentCategoryTagsRoute
+  '/component/icon-test': typeof ComponentIconTestRoute
+  '/component/input-category-tags': typeof ComponentInputCategoryTagsRoute
+  '/component/select-month-drawer': typeof ComponentSelectMonthDrawerRoute
+  '/component/sub-page-header': typeof ComponentSubPageHeaderRoute
+  '/component/text-area': typeof ComponentTextAreaRoute
+  '/component/text-input': typeof ComponentTextInputRoute
+  '/component/toaster': typeof ComponentToasterRoute
+  '/component/underlined-text-input': typeof ComponentUnderlinedTextInputRoute
+  '/expenses/new': typeof ExpensesNewRoute
+  '/expenses': typeof ExpensesIndexRoute
 }
 
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute;
-  '/component/buttons-test': typeof ComponentButtonsTestRoute;
-  '/component/calendar-drawer': typeof ComponentCalendarDrawerRoute;
-  '/component/category-tags': typeof ComponentCategoryTagsRoute;
-  '/component/icon-test': typeof ComponentIconTestRoute;
-  '/component/input-category-tags': typeof ComponentInputCategoryTagsRoute;
-  '/component/select-month-drawer': typeof ComponentSelectMonthDrawerRoute;
-  '/component/sub-page-header': typeof ComponentSubPageHeaderRoute;
-  '/component/text-area': typeof ComponentTextAreaRoute;
-  '/component/text-input': typeof ComponentTextInputRoute;
-  '/component/toaster': typeof ComponentToasterRoute;
-  '/component/underlined-text-input': typeof ComponentUnderlinedTextInputRoute;
-  '/expenses/new': typeof ExpensesNewRoute;
-  '/expenses': typeof ExpensesIndexRoute;
+  '/': typeof IndexRoute
+  '/component/buttons-test': typeof ComponentButtonsTestRoute
+  '/component/calendar-drawer': typeof ComponentCalendarDrawerRoute
+  '/component/category-tags': typeof ComponentCategoryTagsRoute
+  '/component/icon-test': typeof ComponentIconTestRoute
+  '/component/input-category-tags': typeof ComponentInputCategoryTagsRoute
+  '/component/select-month-drawer': typeof ComponentSelectMonthDrawerRoute
+  '/component/sub-page-header': typeof ComponentSubPageHeaderRoute
+  '/component/text-area': typeof ComponentTextAreaRoute
+  '/component/text-input': typeof ComponentTextInputRoute
+  '/component/toaster': typeof ComponentToasterRoute
+  '/component/underlined-text-input': typeof ComponentUnderlinedTextInputRoute
+  '/expenses/new': typeof ExpensesNewRoute
+  '/expenses': typeof ExpensesIndexRoute
 }
 
 export interface FileRoutesById {
-  __root__: typeof rootRoute;
-  '/': typeof IndexRoute;
-  '/component/buttons-test': typeof ComponentButtonsTestRoute;
-  '/component/calendar-drawer': typeof ComponentCalendarDrawerRoute;
-  '/component/category-tags': typeof ComponentCategoryTagsRoute;
-  '/component/icon-test': typeof ComponentIconTestRoute;
-  '/component/input-category-tags': typeof ComponentInputCategoryTagsRoute;
-  '/component/select-month-drawer': typeof ComponentSelectMonthDrawerRoute;
-  '/component/sub-page-header': typeof ComponentSubPageHeaderRoute;
-  '/component/text-area': typeof ComponentTextAreaRoute;
-  '/component/text-input': typeof ComponentTextInputRoute;
-  '/component/toaster': typeof ComponentToasterRoute;
-  '/component/underlined-text-input': typeof ComponentUnderlinedTextInputRoute;
-  '/expenses/new': typeof ExpensesNewRoute;
-  '/expenses/': typeof ExpensesIndexRoute;
+  __root__: typeof rootRoute
+  '/': typeof IndexRoute
+  '/component/buttons-test': typeof ComponentButtonsTestRoute
+  '/component/calendar-drawer': typeof ComponentCalendarDrawerRoute
+  '/component/category-tags': typeof ComponentCategoryTagsRoute
+  '/component/icon-test': typeof ComponentIconTestRoute
+  '/component/input-category-tags': typeof ComponentInputCategoryTagsRoute
+  '/component/select-month-drawer': typeof ComponentSelectMonthDrawerRoute
+  '/component/sub-page-header': typeof ComponentSubPageHeaderRoute
+  '/component/text-area': typeof ComponentTextAreaRoute
+  '/component/text-input': typeof ComponentTextInputRoute
+  '/component/toaster': typeof ComponentToasterRoute
+  '/component/underlined-text-input': typeof ComponentUnderlinedTextInputRoute
+  '/expenses/new': typeof ExpensesNewRoute
+  '/expenses/': typeof ExpensesIndexRoute
 }
 
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
     | '/component/buttons-test'
@@ -292,8 +292,8 @@ export interface FileRouteTypes {
     | '/component/toaster'
     | '/component/underlined-text-input'
     | '/expenses/new'
-    | '/expenses/';
-  fileRoutesByTo: FileRoutesByTo;
+    | '/expenses'
+  fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/component/buttons-test'
@@ -308,7 +308,7 @@ export interface FileRouteTypes {
     | '/component/toaster'
     | '/component/underlined-text-input'
     | '/expenses/new'
-    | '/expenses/';
+    | '/expenses'
   id:
     | '__root__'
     | '/'
@@ -324,25 +324,25 @@ export interface FileRouteTypes {
     | '/component/toaster'
     | '/component/underlined-text-input'
     | '/expenses/new'
-    | '/expenses/';
-  fileRoutesById: FileRoutesById;
+    | '/expenses/'
+  fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  ComponentButtonsTestRoute: typeof ComponentButtonsTestRoute;
-  ComponentCalendarDrawerRoute: typeof ComponentCalendarDrawerRoute;
-  ComponentCategoryTagsRoute: typeof ComponentCategoryTagsRoute;
-  ComponentIconTestRoute: typeof ComponentIconTestRoute;
-  ComponentInputCategoryTagsRoute: typeof ComponentInputCategoryTagsRoute;
-  ComponentSelectMonthDrawerRoute: typeof ComponentSelectMonthDrawerRoute;
-  ComponentSubPageHeaderRoute: typeof ComponentSubPageHeaderRoute;
-  ComponentTextAreaRoute: typeof ComponentTextAreaRoute;
-  ComponentTextInputRoute: typeof ComponentTextInputRoute;
-  ComponentToasterRoute: typeof ComponentToasterRoute;
-  ComponentUnderlinedTextInputRoute: typeof ComponentUnderlinedTextInputRoute;
-  ExpensesNewRoute: typeof ExpensesNewRoute;
-  ExpensesIndexRoute: typeof ExpensesIndexRoute;
+  IndexRoute: typeof IndexRoute
+  ComponentButtonsTestRoute: typeof ComponentButtonsTestRoute
+  ComponentCalendarDrawerRoute: typeof ComponentCalendarDrawerRoute
+  ComponentCategoryTagsRoute: typeof ComponentCategoryTagsRoute
+  ComponentIconTestRoute: typeof ComponentIconTestRoute
+  ComponentInputCategoryTagsRoute: typeof ComponentInputCategoryTagsRoute
+  ComponentSelectMonthDrawerRoute: typeof ComponentSelectMonthDrawerRoute
+  ComponentSubPageHeaderRoute: typeof ComponentSubPageHeaderRoute
+  ComponentTextAreaRoute: typeof ComponentTextAreaRoute
+  ComponentTextInputRoute: typeof ComponentTextInputRoute
+  ComponentToasterRoute: typeof ComponentToasterRoute
+  ComponentUnderlinedTextInputRoute: typeof ComponentUnderlinedTextInputRoute
+  ExpensesNewRoute: typeof ExpensesNewRoute
+  ExpensesIndexRoute: typeof ExpensesIndexRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
@@ -360,11 +360,11 @@ const rootRouteChildren: RootRouteChildren = {
   ComponentUnderlinedTextInputRoute: ComponentUnderlinedTextInputRoute,
   ExpensesNewRoute: ExpensesNewRoute,
   ExpensesIndexRoute: ExpensesIndexRoute,
-};
+}
 
 export const routeTree = rootRoute
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
 /* ROUTE_MANIFEST_START
 {

--- a/src/app/routes/expenses.new.tsx
+++ b/src/app/routes/expenses.new.tsx
@@ -12,7 +12,7 @@ export function AboutPage() {
   return (
     <Layout>
       <SubPageHeader title='지출 내역 추가' back />
-      <ExpenseForm submitButtonText='저장' />
+      <ExpenseForm />
     </Layout>
   );
 }

--- a/src/app/routes/expenses.new.tsx
+++ b/src/app/routes/expenses.new.tsx
@@ -12,7 +12,7 @@ export function AboutPage() {
   return (
     <Layout>
       <SubPageHeader title='지출 내역 추가' back />
-      <ExpenseForm />
+      <ExpenseForm submitButtonText='저장' />
     </Layout>
   );
 }

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,0 +1,165 @@
+import * as LabelPrimitive from '@radix-ui/react-label';
+import { Slot } from '@radix-ui/react-slot';
+import * as React from 'react';
+import {
+  Controller,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+  FormProvider,
+  useFormContext,
+  useFormState,
+} from 'react-hook-form';
+
+import { Label } from '@/components/ui/label';
+import { cn } from '@/shared/ui/styles/utils';
+
+const Form = FormProvider;
+
+interface FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> {
+  name: TName;
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+);
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+};
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = React.useContext(FormItemContext);
+  const { getFieldState } = useFormContext();
+  const formState = useFormState({ name: fieldContext.name });
+  const fieldState = getFieldState(fieldContext.name, formState);
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!fieldContext) {
+    throw new Error('useFormField should be used within <FormField>');
+  }
+
+  const { id } = itemContext;
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  };
+};
+
+interface FormItemContextValue {
+  id: string;
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+);
+
+function FormItem({ className, ...props }: React.ComponentProps<'div'>) {
+  const id = React.useId();
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div
+        data-slot='form-item'
+        className={cn('grid gap-2', className)}
+        {...props}
+      />
+    </FormItemContext.Provider>
+  );
+}
+
+function FormLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  const { error, formItemId } = useFormField();
+
+  return (
+    <Label
+      data-slot='form-label'
+      data-error={!!error}
+      className={cn('data-[error=true]:text-destructive', className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  );
+}
+
+function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
+  const { error, formItemId, formDescriptionId, formMessageId } =
+    useFormField();
+
+  return (
+    <Slot
+      data-slot='form-control'
+      id={formItemId}
+      aria-describedby={
+        !error ? formDescriptionId : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  );
+}
+
+function FormDescription({ className, ...props }: React.ComponentProps<'p'>) {
+  const { formDescriptionId } = useFormField();
+
+  return (
+    <p
+      data-slot='form-description'
+      id={formDescriptionId}
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
+  const { error, formMessageId } = useFormField();
+  const body = error ? String(error.message ?? '') : props.children;
+
+  if (!body) {
+    return null;
+  }
+
+  return (
+    <p
+      data-slot='form-message'
+      id={formMessageId}
+      className={cn('text-destructive text-sm', className)}
+      {...props}
+    >
+      {body}
+    </p>
+  );
+}
+
+export {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  useFormField,
+};

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,5 +1,6 @@
 import * as LabelPrimitive from '@radix-ui/react-label';
 import { Slot } from '@radix-ui/react-slot';
+import DOMPurify from 'dompurify';
 import * as React from 'react';
 import {
   Controller,
@@ -135,7 +136,11 @@ function FormDescription({ className, ...props }: React.ComponentProps<'p'>) {
 
 function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
   const { error, formMessageId } = useFormField();
-  const body = error ? String(error.message ?? '') : props.children;
+  const sanitizedMessage = error?.message
+    ? DOMPurify.sanitize(String(error.message))
+    : '';
+
+  const body = error ? sanitizedMessage : props.children;
 
   if (!body) {
     return null;

--- a/src/features/expense/api/useExpenseQuery.ts
+++ b/src/features/expense/api/useExpenseQuery.ts
@@ -6,7 +6,9 @@ import { DailyExpense, Expense } from '@/features/expense/model/types/Expense';
 import { queryKeys } from '../consts';
 
 const fetchExpenses = async (): Promise<Expense[]> => {
-  const res = await fetch('http://api.blink-it.me/expense/expense/expenses/');
+  const res = await fetch(
+    `${import.meta.env.VITE_API_URL}/expense/expense/expenses/`
+  );
 
   if (!res.ok) {
     throw new Error('Failed to fetch expenses');

--- a/src/features/expense/api/useExpenseQuery.ts
+++ b/src/features/expense/api/useExpenseQuery.ts
@@ -6,7 +6,7 @@ import { DailyExpense, Expense } from '@/features/expense/model/types/Expense';
 import { queryKeys } from '../consts';
 
 const fetchExpenses = async (): Promise<Expense[]> => {
-  const res = await fetch('/mock-data/expenses.json');
+  const res = await fetch('http://api.blink-it.me/expense/expense/expenses/');
 
   if (!res.ok) {
     throw new Error('Failed to fetch expenses');

--- a/src/features/expense/ui/CalendarDrawer/CalendarDrawer.test.tsx
+++ b/src/features/expense/ui/CalendarDrawer/CalendarDrawer.test.tsx
@@ -5,13 +5,16 @@ import CalendarDrawer, { CalendarDrawerProps } from './CalendarDrawer';
 
 describe('CalendarDrawer', () => {
   const props: CalendarDrawerProps = {
+    id: 'base-id',
     trigger: 'trigger',
     date: new Date(),
     setDate: vi.fn(),
   };
 
-  const renderElement = ({ trigger, date, setDate }: CalendarDrawerProps) =>
-    render(<CalendarDrawer trigger={trigger} date={date} setDate={setDate} />);
+  const renderElement = ({ id, trigger, date, setDate }: CalendarDrawerProps) =>
+    render(
+      <CalendarDrawer id={id} trigger={trigger} date={date} setDate={setDate} />
+    );
 
   it('renders drawer trigger.', () => {
     const { getByRole } = renderElement({ ...props });

--- a/src/features/expense/ui/CalendarDrawer/CalendarDrawer.tsx
+++ b/src/features/expense/ui/CalendarDrawer/CalendarDrawer.tsx
@@ -15,12 +15,14 @@ import {
 import SubmitButton from '@/shared/ui/SubmitButton';
 
 export interface CalendarDrawerProps {
+  id: string;
   trigger: React.ReactNode;
   date: Date | undefined;
   setDate: (newDate: Date | undefined) => void;
 }
 
 const CalendarDrawer: React.FC<CalendarDrawerProps> = ({
+  id,
   trigger,
   date,
   setDate,
@@ -33,7 +35,7 @@ const CalendarDrawer: React.FC<CalendarDrawerProps> = ({
   );
   return (
     <Drawer>
-      <DrawerTrigger>{trigger}</DrawerTrigger>
+      <DrawerTrigger id={id}>{trigger}</DrawerTrigger>
       <DrawerContent className='w-full max-w-sm mx-auto p-6'>
         <DrawerHeader className='flex flex-row items-center justify-between rounded-t-full p-0'>
           <div className='flex-1' />

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.test.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.test.tsx
@@ -1,13 +1,18 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
 import { describe, it } from 'vitest';
 
 import ExpenseForm, { ExpenseFormProps } from './ExpenseForm';
 
 describe('ExpenseForm', () => {
-  const renderElement = ({
-    submitButtonText = 'submit button text',
-  }: ExpenseFormProps) =>
-    render(<ExpenseForm submitButtonText={submitButtonText} />);
+  const testQueryClient = new QueryClient();
+
+  const renderElement = ({ expense = undefined }: ExpenseFormProps) =>
+    render(
+      <QueryClientProvider client={testQueryClient}>
+        <ExpenseForm expense={expense} />
+      </QueryClientProvider>
+    );
 
   describe('date', () => {
     it('renders label.', () => {
@@ -48,11 +53,25 @@ describe('ExpenseForm', () => {
     });
   });
 
-  it('renders provided submitButtonText.', () => {
-    const text = 'submit button text example';
-    const { getByRole } = renderElement({ submitButtonText: text });
-    const submitButton = getByRole('button', { name: text });
+  describe('submit button', () => {
+    it('renders 추가 when expense is not provided.', () => {
+      const { getByRole } = renderElement({});
+      const submitButton = getByRole('button', { name: '추가' });
+      expect(submitButton).toBeInTheDocument();
+    });
 
-    expect(submitButton).toBeInTheDocument();
+    it('renders 저장 when expense is provided.', () => {
+      const { getByRole } = renderElement({
+        expense: {
+          uid: '',
+          date: new Date(),
+          memo: '',
+          categories: [],
+          amount: 0,
+        },
+      });
+      const submitButton = getByRole('button', { name: '저장' });
+      expect(submitButton).toBeInTheDocument();
+    });
   });
 });

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.test.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.test.tsx
@@ -1,24 +1,19 @@
-import { describe, it } from 'vitest';
 import { render } from '@testing-library/react';
+import { describe, it } from 'vitest';
 
-import ExpenseForm from './ExpenseForm';
+import ExpenseForm, { ExpenseFormProps } from './ExpenseForm';
 
 describe('ExpenseForm', () => {
-  const renderExpenseForm = () => render(<ExpenseForm />);
+  const renderElement = ({
+    submitButtonText = 'submit button text',
+  }: ExpenseFormProps) =>
+    render(<ExpenseForm submitButtonText={submitButtonText} />);
 
-  it('renders label elements.', () => {
-    const { getByLabelText } = renderExpenseForm();
+  it('renders provided submitButtonText.', () => {
+    const text = 'submit button text example';
+    const { getByRole } = renderElement({ submitButtonText: text });
+    const submitButton = getByRole('button', { name: text });
 
-    expect(getByLabelText('날짜')).toBeInTheDocument();
-    expect(getByLabelText('카테고리')).toBeInTheDocument();
-    expect(getByLabelText('메모')).toBeInTheDocument();
-    expect(getByLabelText('금액')).toBeInTheDocument();
-  });
-
-  it(`renders '저장' submit button.`, () => {
-    const { getByRole } = renderExpenseForm();
-    const submitButton = getByRole('button', { name: '저장' });
-
-    expect(submitButton).not.toBeNull();
+    expect(submitButton).toBeInTheDocument();
   });
 });

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.test.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.test.tsx
@@ -9,6 +9,45 @@ describe('ExpenseForm', () => {
   }: ExpenseFormProps) =>
     render(<ExpenseForm submitButtonText={submitButtonText} />);
 
+  describe('date', () => {
+    it('renders label.', () => {
+      const { getByLabelText } = renderElement({});
+      const label = getByLabelText('날짜');
+      expect(label).toBeInTheDocument();
+    });
+  });
+
+  describe('memo', () => {
+    it('renders label.', () => {
+      const { getByLabelText } = renderElement({});
+      const label = getByLabelText('메모');
+      expect(label).toBeInTheDocument();
+    });
+  });
+
+  describe('category', () => {
+    it('renders label.', () => {
+      const { getByLabelText } = renderElement({});
+      const label = getByLabelText('카테고리');
+      expect(label).toBeInTheDocument();
+    });
+
+    it('renders CategorySettingButton.', () => {
+      const { getByLabelText } = renderElement({});
+      const buttonLabel = getByLabelText('카테고리 설정 버튼');
+      expect(buttonLabel).toBeInTheDocument();
+      expect(buttonLabel.tagName.toLowerCase()).toBe('button');
+    });
+  });
+
+  describe('amount', () => {
+    it('renders label.', () => {
+      const { getByLabelText } = renderElement({});
+      const label = getByLabelText('금액');
+      expect(label).toBeInTheDocument();
+    });
+  });
+
   it('renders provided submitButtonText.', () => {
     const text = 'submit button text example';
     const { getByRole } = renderElement({ submitButtonText: text });

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 import { Button, buttonVariants } from '@/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+} from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import CategoryTag from '@/features/category/ui/CategoryTag';
@@ -28,97 +37,110 @@ const CalendarDrawerTrigger = ({ date }: { date: Date }) => {
 };
 
 const ExpenseForm: React.FC = () => {
-  const [form, setForm] = React.useState<Omit<Expense, 'uid'>>({
-    date: new Date(),
-    categories: [
-      { uid: '1', name: '세글자' },
-      { uid: '2', name: '열글자열글자열글자열' },
-      { uid: '3', name: '스무글자스무글자스무글자스무글자' },
-    ],
-    memo: '',
-    amount: 0,
+  const form = useForm<Omit<Expense, 'uid'>>({
+    defaultValues: {
+      date: new Date(),
+      categories: [
+        { uid: '1', name: '세글자' },
+        { uid: '2', name: '열글자열글자열글자열' },
+        { uid: '3', name: '스무글자스무글자스무글자스무글자' },
+      ],
+      memo: '',
+      amount: 0,
+    },
   });
 
-  const handleChangeDate = (newDate: Date | undefined) => {
-    if (newDate !== undefined) {
-      setForm({ ...form, date: newDate });
-    }
-  };
-
-  const handleChangeMemo = ({
-    newMemo,
-    maxLength = EXPENSE_MEMO_MAX_LEN,
-  }: {
-    newMemo: string;
-    maxLength?: number | undefined;
-  }) => {
-    if (newMemo.length <= maxLength) {
-      setForm({ ...form, memo: newMemo });
-    }
-  };
-
   return (
-    <form className='flex flex-col gap-6 h-screen pt-6 px-5'>
-      <div className='flex flex-row items-center'>
-        <Label id='date' className='text-[15px] font-semibold text-[#222] p-0'>
-          날짜
-        </Label>
-        <div className='ml-auto'>
-          <CalendarDrawer
-            trigger={<CalendarDrawerTrigger date={form.date} />}
-            date={form.date}
-            setDate={handleChangeDate}
-          />
+    <Form {...form}>
+      <form className='flex flex-col gap-6 h-screen pt-6 px-5'>
+        <FormField
+          control={form.control}
+          name='date'
+          render={({ field }) => (
+            <FormItem className='flex flex-row items-center'>
+              <Label
+                id='date'
+                className='text-[15px] font-semibold text-[#222] p-0'
+              >
+                날짜
+              </Label>
+              <div className='ml-auto'>
+                <CalendarDrawer
+                  trigger={<CalendarDrawerTrigger date={field.value} />}
+                  date={field.value}
+                  setDate={() => {
+                    field.onChange(field.value);
+                  }}
+                />
+              </div>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name='memo'
+          render={({ field }) => (
+            <FormItem>
+              <FormControl>
+                <LabeledTextarea
+                  label='메모'
+                  id='memo'
+                  placeholder={`어디서, 무엇을 결제하셨나요?\r\n그때 기분은 어땠나요?`}
+                  value={field.value}
+                  onChange={(e) => {
+                    if (e.length <= EXPENSE_MEMO_MAX_LEN) {
+                      field.onChange(e);
+                    }
+                  }}
+                  state='default'
+                  maxLength={EXPENSE_MEMO_MAX_LEN}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name='categories'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className='text-[15px] font-semibold text-[#222]'>
+                카테고리
+              </FormLabel>
+              <Button
+                variant='ghost'
+                className='h-auto text-[13px] ml-auto py-1 px-2'
+              >
+                설정
+              </Button>
+              <div className='flex flex-row gap-2 flex-wrap'>
+                {field.value.map((category) => (
+                  <CategoryTag key={category.uid} tagName={category.name} />
+                ))}
+              </div>
+            </FormItem>
+          )}
+        />
+        <div className='flex flex-col gap-2'>
+          <label>금액</label>
+          <div className='relative'>
+            <Input
+              type='number'
+              className='w-full h-11 auto border-box px-3 pl-2 pr-12 rounded-md border-1 border-black/10 text-right'
+            />
+            <span className='absolute inset-y-0 right-3 flex items-center pointer-events-none text-gray-700'>
+              원
+            </span>
+          </div>
         </div>
-      </div>
-      <LabeledTextarea
-        label='메모'
-        id='memo'
-        placeholder={`어디서, 무엇을 결제하셨나요?\r\n그때 기분은 어땠나요?`}
-        value={form.memo}
-        onChange={(e) => {
-          handleChangeMemo({ newMemo: e });
-        }}
-        state='default'
-        maxLength={EXPENSE_MEMO_MAX_LEN}
-      />
-      <div className='flex flex-col gap-2'>
-        <div className='flex flex-row'>
-          <Label className='text-[15px] font-semibold text-[#222]'>
-            카테고리
-          </Label>
-          <Button
-            variant='ghost'
-            className='h-auto text-[13px] ml-auto py-1 px-2'
-          >
-            설정
-          </Button>
-        </div>
-        <div className='flex flex-row gap-2 flex-wrap'>
-          {form.categories.map((category) => (
-            <CategoryTag key={category.uid} tagName={category.name} />
-          ))}
-        </div>
-      </div>
-      <div className='flex flex-col gap-2'>
-        <label>금액</label>
-        <div className='relative'>
-          <Input
-            type='number'
-            className='w-full h-11 auto border-box px-3 pl-2 pr-12 rounded-md border-1 border-black/10 text-right'
-          />
-          <span className='absolute inset-y-0 right-3 flex items-center pointer-events-none text-gray-700'>
-            원
-          </span>
-        </div>
-      </div>
-      <Button
-        type='submit'
-        className='h-13 text-[15px] font-semibold mt-auto mb-5 rounded-full'
-      >
-        저장
-      </Button>
-    </form>
+        <Button
+          type='submit'
+          className='h-13 text-[15px] font-semibold mt-auto mb-5 rounded-full'
+        >
+          저장
+        </Button>
+      </form>
+    </Form>
   );
 };
 

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useForm } from 'react-hook-form';
-import { z } from 'zod';
 
 import { Button, buttonVariants } from '@/components/ui/button';
 import {
@@ -16,7 +15,6 @@ import CategoryTag from '@/features/category/ui/CategoryTag';
 import { EXPENSE_MEMO_MAX_LEN } from '@/features/expense/consts';
 import { Expense } from '@/features/expense/model/types/Expense';
 import CalendarDrawer from '@/features/expense/ui/CalendarDrawer';
-import { ExpenseForm } from '@/features/expense/ui/ExpenseForm';
 import ArrowRight from '@/shared/ui/icons/ArrowRight';
 import LabeledTextarea from '@/shared/ui/LabeledTextarea';
 import { cn } from '@/shared/ui/styles/utils';
@@ -114,10 +112,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ submitButtonText }) => {
                 <FormLabel className='text-[15px] font-semibold text-[#222]'>
                   카테고리
                 </FormLabel>
-                <Button
-                  variant='ghost'
-                  className='h-auto text-[13px] ml-auto py-1 px-2'
-                >
+                <Button className='rounded-full bg-[#efefef] hover:bg-accent h-auto text-[13px] text-[#555] ml-auto py-1 px-2'>
                   설정
                 </Button>
               </div>

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useForm } from 'react-hook-form';
+import { NumericFormat } from 'react-number-format';
 
 import { Button, buttonVariants } from '@/components/ui/button';
 import {
@@ -9,7 +10,6 @@ import {
   FormItem,
   FormLabel,
 } from '@/components/ui/form';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import CategoryTag from '@/features/category/ui/CategoryTag';
 import { EXPENSE_MEMO_MAX_LEN } from '@/features/expense/consts';
@@ -137,19 +137,18 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ submitButtonText }) => {
         <FormField
           control={form.control}
           name='amount'
-          render={() => (
+          render={({ field }) => (
             <FormItem className='flex flex-col gap-2'>
               <FormLabel>금액</FormLabel>
               <FormControl>
-                <div className='relative'>
-                  <Input
-                    type='number'
-                    className='w-full h-11 auto border-box px-3 pl-2 pr-12 rounded-md border-1 border-black/10 text-right'
-                  />
-                  <span className='absolute inset-y-0 right-3 flex items-center pointer-events-none text-gray-700'>
-                    원
-                  </span>
-                </div>
+                <NumericFormat
+                  value={field.value}
+                  onChange={(e) => {
+                    field.onChange(e.target.value);
+                  }}
+                  placeholder='금액을 입력해주세요.'
+                  className='h-12 w-full p-4 rounded-md border border-black/10 text-[15px] text-[#222]'
+                />
               </FormControl>
             </FormItem>
           )}

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -54,9 +54,16 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ submitButtonText }) => {
     },
   });
 
+  const onSubmit = (values: Omit<Expense, 'uid'>) => {
+    console.log(values);
+  };
+
   return (
     <Form {...form}>
-      <form className='flex flex-col gap-6 h-screen pt-6 px-5'>
+      <form
+        className='flex flex-col gap-6 h-screen pt-6 px-5'
+        onSubmit={() => form.handleSubmit(onSubmit)}
+      >
         <FormField
           control={form.control}
           name='date'

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -105,15 +105,17 @@ const ExpenseForm: React.FC = () => {
           name='categories'
           render={({ field }) => (
             <FormItem>
-              <FormLabel className='text-[15px] font-semibold text-[#222]'>
-                카테고리
-              </FormLabel>
-              <Button
-                variant='ghost'
-                className='h-auto text-[13px] ml-auto py-1 px-2'
-              >
-                설정
-              </Button>
+              <div className='flex flex-row items-center'>
+                <FormLabel className='text-[15px] font-semibold text-[#222]'>
+                  카테고리
+                </FormLabel>
+                <Button
+                  variant='ghost'
+                  className='h-auto text-[13px] ml-auto py-1 px-2'
+                >
+                  설정
+                </Button>
+              </div>
               <div className='flex flex-row gap-2 flex-wrap'>
                 {field.value.map((category) => (
                   <CategoryTag key={category.uid} tagName={category.name} />

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -16,6 +16,7 @@ import CategoryTag from '@/features/category/ui/CategoryTag';
 import { EXPENSE_MEMO_MAX_LEN } from '@/features/expense/consts';
 import { Expense } from '@/features/expense/model/types/Expense';
 import CalendarDrawer from '@/features/expense/ui/CalendarDrawer';
+import { ExpenseForm } from '@/features/expense/ui/ExpenseForm';
 import ArrowRight from '@/shared/ui/icons/ArrowRight';
 import LabeledTextarea from '@/shared/ui/LabeledTextarea';
 import { cn } from '@/shared/ui/styles/utils';
@@ -37,7 +38,11 @@ const CalendarDrawerTrigger = ({ date }: { date: Date }) => {
   );
 };
 
-const ExpenseForm: React.FC = () => {
+export interface ExpenseFormProps {
+  submitButtonText?: string;
+}
+
+const ExpenseForm: React.FC<ExpenseFormProps> = ({ submitButtonText }) => {
   const form = useForm<Omit<Expense, 'uid'>>({
     defaultValues: {
       date: new Date(),
@@ -140,7 +145,7 @@ const ExpenseForm: React.FC = () => {
           type='submit'
           className='h-13 text-[15px] font-semibold mt-auto mb-5 rounded-full'
         >
-          저장
+          {submitButtonText}
         </Button>
       </form>
     </Form>

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -10,7 +10,6 @@ import {
   FormItem,
   FormLabel,
 } from '@/components/ui/form';
-import { Label } from '@/components/ui/label';
 import CategoryTag from '@/features/category/ui/CategoryTag';
 import { EXPENSE_MEMO_MAX_LEN } from '@/features/expense/consts';
 import { Expense } from '@/features/expense/model/types/Expense';
@@ -69,21 +68,23 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ submitButtonText }) => {
           name='date'
           render={({ field }) => (
             <FormItem className='flex flex-row items-center'>
-              <Label
-                id='date'
+              <FormLabel
+                htmlFor='date'
                 className='text-[15px] font-semibold text-[#222] p-0'
               >
                 날짜
-              </Label>
-              <div className='ml-auto'>
+              </FormLabel>
+              <FormControl className='ml-auto'>
                 <CalendarDrawer
+                  id='date'
                   trigger={<CalendarDrawerTrigger date={field.value} />}
                   date={field.value}
                   setDate={(newDate) => {
                     field.onChange(newDate);
                   }}
+                  {...field}
                 />
-              </div>
+              </FormControl>
             </FormItem>
           )}
         />
@@ -116,10 +117,14 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ submitButtonText }) => {
           render={({ field }) => (
             <FormItem>
               <div className='flex flex-row items-center'>
-                <FormLabel className='text-[15px] font-semibold text-[#222]'>
+                <FormLabel
+                  htmlFor='categories'
+                  className='text-[15px] font-semibold text-[#222]'
+                >
                   카테고리
                 </FormLabel>
                 <Button
+                  id='categories'
                   aria-label='카테고리 설정 버튼'
                   className='rounded-full bg-[#efefef] hover:bg-accent h-auto text-[13px] text-[#555] ml-auto py-1 px-2'
                 >

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -147,10 +147,14 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ submitButtonText }) => {
               <FormLabel>금액</FormLabel>
               <FormControl>
                 <NumericFormat
+                  inputMode='numeric'
                   value={field.value}
                   onChange={(e) => {
-                    field.onChange(e.target.value);
+                    field.onChange(parseInt(e.target.value));
                   }}
+                  allowNegative={false}
+                  thousandSeparator=','
+                  suffix='원'
                   placeholder='금액을 입력해주세요.'
                   className='h-12 w-full p-4 rounded-md border border-black/10 text-[15px] text-[#222]'
                 />

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -69,8 +69,8 @@ const ExpenseForm: React.FC = () => {
                 <CalendarDrawer
                   trigger={<CalendarDrawerTrigger date={field.value} />}
                   date={field.value}
-                  setDate={() => {
-                    field.onChange(field.value);
+                  setDate={(newDate) => {
+                    field.onChange(newDate);
                   }}
                 />
               </div>

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -40,14 +40,10 @@ const CalendarDrawerTrigger = ({ date }: { date: Date }) => {
 };
 
 export interface ExpenseFormProps {
-  submitButtonText?: string;
   expense?: Expense;
 }
 
-const ExpenseForm: React.FC<ExpenseFormProps> = ({
-  submitButtonText,
-  expense,
-}) => {
+const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense }) => {
   const updateExpense = useUpdateExpense();
   const addExpense = useAddExpense();
 
@@ -184,7 +180,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
           type='submit'
           className='h-13 text-[15px] font-semibold mt-auto mb-5 rounded-full'
         >
-          {submitButtonText}
+          {expense ? '저장' : '추가'}
         </Button>
       </form>
     </Form>

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -24,8 +24,9 @@ const CalendarDrawerTrigger = ({ date }: { date: Date }) => {
   return (
     <div
       className={cn(
-        'flex flex-row items-center ml-auto',
-        buttonVariants({ variant: 'ghost' })
+        buttonVariants({ variant: 'ghost' }),
+        'has-[>svg]:p-0',
+        'flex flex-row items-center h-auto w-auto ml-auto p-0'
       )}
     >
       <p className='mr-1 text-[15px] font-normal text-[#28a745]'>

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -119,7 +119,10 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ submitButtonText }) => {
                 <FormLabel className='text-[15px] font-semibold text-[#222]'>
                   카테고리
                 </FormLabel>
-                <Button className='rounded-full bg-[#efefef] hover:bg-accent h-auto text-[13px] text-[#555] ml-auto py-1 px-2'>
+                <Button
+                  aria-label='카테고리 설정 버튼'
+                  className='rounded-full bg-[#efefef] hover:bg-accent h-auto text-[13px] text-[#555] ml-auto py-1 px-2'
+                >
                   설정
                 </Button>
               </div>

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -134,18 +134,26 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ submitButtonText }) => {
             </FormItem>
           )}
         />
-        <div className='flex flex-col gap-2'>
-          <label>금액</label>
-          <div className='relative'>
-            <Input
-              type='number'
-              className='w-full h-11 auto border-box px-3 pl-2 pr-12 rounded-md border-1 border-black/10 text-right'
-            />
-            <span className='absolute inset-y-0 right-3 flex items-center pointer-events-none text-gray-700'>
-              원
-            </span>
-          </div>
-        </div>
+        <FormField
+          control={form.control}
+          name='amount'
+          render={() => (
+            <FormItem className='flex flex-col gap-2'>
+              <FormLabel>금액</FormLabel>
+              <FormControl>
+                <div className='relative'>
+                  <Input
+                    type='number'
+                    className='w-full h-11 auto border-box px-3 pl-2 pr-12 rounded-md border-1 border-black/10 text-right'
+                  />
+                  <span className='absolute inset-y-0 right-3 flex items-center pointer-events-none text-gray-700'>
+                    원
+                  </span>
+                </div>
+              </FormControl>
+            </FormItem>
+          )}
+        />
         <Button
           type='submit'
           className='h-13 text-[15px] font-semibold mt-auto mb-5 rounded-full'

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -75,7 +75,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense }) => {
     <Form {...form}>
       <form
         className='flex flex-col gap-6 h-screen pt-6 px-5'
-        onSubmit={() => form.handleSubmit(handleOnSubmit)}
+        onSubmit={form.handleSubmit(handleOnSubmit)}
       >
         <FormField
           control={form.control}

--- a/src/shared/ui/LabeledTextarea/LabeledTextarea.tsx
+++ b/src/shared/ui/LabeledTextarea/LabeledTextarea.tsx
@@ -38,7 +38,7 @@ const LabeledTextarea: React.FC<LabeledTextareaProps> = ({
           onChange(e.target.value);
         }}
         className={cn(
-          'h-38 rounded-xl border text-left leading-normal resize-none text-[15px]',
+          'h-38 rounded-xl border text-left leading-normal resize-none text-[15px] p-4',
           'focus:border-[#222]',
           'placeholder:whitespace-pre-line',
           state === 'default' && 'border-[#cccccc]',


### PR DESCRIPTION
- #57 
- 소요시간: 7시간
  - 적당한 크기로 자르지 못함. 
  - ExpenseForm의 컴포넌트들은 디자인시스템에 추가하지 않아 순수 jsx으로 작업하다가 shadcn/ui form 을 적용하여 시간을 단축. Form에 대한 렌더링 시간이 오래걸림.
  - 작업 중 tanstack-router, tanstack-query 관련 테스트 들도 구현하고 라우터 관련 경로 설정하는데도 고민하니 맥락이 너무 커져 집중하지 못함. 
    - PR이 커지면 중간에 나누는 작업을 안했더니 생긴 문제.
  - ExpenseForm
    - shadcn/ui form으로 변경
    - expense api 추가
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- 새 폼 컴포넌트 세트를 도입하여 경비 추가 및 수정 양식이 보다 직관적이고 접근성 있게 개선되었습니다.
	- 경비 데이터는 외부 API를 통해 최신 정보로 업데이트되어 더욱 신뢰성 있는 서비스를 제공합니다.
	- 입력 필드에 대한 검증 및 동적 버튼 레이블("추가" 또는 "저장") 적용으로 사용자가 쉽게 작업할 수 있습니다.
	- 새로운 환경 변수 `VITE_API_URL`이 추가되어 API URL을 설정할 수 있습니다.
- **스타일**
	- 텍스트 영역에 패딩이 추가되어 가독성이 크게 향상되었습니다.
- **버그 수정**
	- ESLint 구성에서 무시할 디렉토리 목록이 업데이트되어 코드 품질 유지에 기여합니다.
- **의존성 추가**
	- 여러 새로운 라이브러리가 프로젝트에 추가되어 기능이 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->