### PR TITLE
닉네임 수정 페이지를 form으로 변경, SubmitButton props 수정 

### DIFF
--- a/src/app/routes/settings.account.tsx
+++ b/src/app/routes/settings.account.tsx
@@ -94,7 +94,7 @@ function RouteComponent() {
       <SubPageHeader title='회원정보' back />
       <Form {...form}>
         <form
-          className='flex flex-col flex-1'
+          className='flex flex-col flex-1 pt-6 pb-8 px-5'
           // eslint-disable-next-line @typescript-eslint/no-misused-promises
           onSubmit={form.handleSubmit(onSubmit)}
         >
@@ -132,7 +132,7 @@ function RouteComponent() {
               </FormItem>
             )}
           />
-          <div className='mt-auto mb-8 px-5'>
+          <div className='mt-auto'>
             <SubmitButton type='submit' text='저장' className='w-full' />
           </div>
         </form>

--- a/src/app/routes/settings.account.tsx
+++ b/src/app/routes/settings.account.tsx
@@ -1,6 +1,9 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import React from 'react';
+import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
+import { z } from 'zod';
 
 import { Button } from '@/components/ui/button';
 import { useMe, useUpdateMe } from '@/features/auth/api/useAuth';
@@ -12,26 +15,51 @@ export const Route = createFileRoute('/settings/account')({
   component: RouteComponent,
 });
 
+import { Form, FormControl, FormField, FormItem } from '@/components/ui/form';
+import SubmitButton from '@/shared/ui/SubmitButton';
+
+const formSchema = z.object({
+  nickname: z
+    .string()
+    .min(1, {
+      message: '닉네임은 최소 1글자 이상이어야 해요.',
+    })
+    .max(20, {
+      message: '닉네임은 최대 20글자까지 입력할 수 있어요.',
+    }),
+  email: z.string(),
+});
+
 function RouteComponent() {
   const navigate = useNavigate();
   const updateMe = useUpdateMe();
   const { data, isError, error } = useMe();
 
-  const [nickname, setNickname] = React.useState<string>('');
-  const [email, setEmail] = React.useState<string>('');
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { nickname: '', email: '' },
+  });
 
   if (isError) {
     throw error;
   }
 
   React.useEffect(() => {
-    if (data?.nickname !== undefined && data.email !== undefined) {
-      setNickname(data.nickname ?? '');
-      setEmail(data.email);
+    if (data) {
+      if (data.nickname !== undefined) {
+        form.setValue('nickname', data.nickname);
+      }
+
+      if (data.email !== undefined) {
+        form.setValue('email', data.email);
+      }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
 
-  const onSubmit = () => {
+  const onSubmit = (values: z.infer<typeof formSchema>) => {
+    const nickname = values.nickname;
+
     if (nickname.length === 0) {
       toast.error('닉네임은 최소 1글자 이상이어야 해요.');
       return;
@@ -49,16 +77,13 @@ function RouteComponent() {
       // data.isSuperuser !== undefined
     ) {
       updateMe.mutate(
-        { uid: data.uid, email: data.email, nickname },
+        { ...data, nickname },
         {
           onSuccess: () => {
-            toast.success('회원정보를 성공적으로 업데이트했습니다.');
             void navigate({ to: '/expenses' });
           },
-          onError: (error) => {
-            toast.error(
-              '회원정보 업데이트 중 오류가 발생했습니다. ' + error.message
-            );
+          onError: () => {
+            toast.error('닉네임 설정에 실패했어요.');
           },
         }
       );
@@ -68,20 +93,51 @@ function RouteComponent() {
   return (
     <Layout guarded>
       <SubPageHeader title='회원정보' back />
-      <LabeledTextInput
-        id='nickname'
-        label='닉네임'
-        value={nickname}
-        onChange={setNickname}
-        maxLength={20}
-      />
-      <LabeledTextInput
-        id='email'
-        label='이메일'
-        value={email}
-        state='disabled'
-      />
-      <Button onClick={onSubmit}>저장</Button>
+      <Form {...form}>
+        <form
+          className='flex flex-col flex-1'
+          // eslint-disable-next-line @typescript-eslint/no-misused-promises
+          onSubmit={form.handleSubmit(onSubmit)}
+        >
+          <FormField
+            control={form.control}
+            name='nickname'
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <LabeledTextInput
+                    id='nickname'
+                    label='닉네임'
+                    value={field.value}
+                    onChange={field.onChange}
+                    maxLength={20}
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name='email'
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <LabeledTextInput
+                    id='email'
+                    label='이메일'
+                    value={field.value}
+                    onChange={field.onChange}
+                    state='disabled'
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <div className='mt-auto mb-8 px-5'>
+            <SubmitButton type='submit' text='저장' className='w-full' />
+          </div>
+        </form>
+      </Form>
     </Layout>
   );
 }

--- a/src/app/routes/settings.account.tsx
+++ b/src/app/routes/settings.account.tsx
@@ -5,7 +5,6 @@ import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
 
-import { Button } from '@/components/ui/button';
 import { useMe, useUpdateMe } from '@/features/auth/api/useAuth';
 import LabeledTextInput from '@/shared/ui/LabeledTextInput';
 import Layout from '@/shared/ui/layout/Layout';

--- a/src/app/routes/settings.account.tsx
+++ b/src/app/routes/settings.account.tsx
@@ -53,6 +53,7 @@ function RouteComponent() {
         {
           onSuccess: () => {
             toast.success('회원정보를 성공적으로 업데이트했습니다.');
+            void navigate({ to: '/expenses' });
           },
           onError: (error) => {
             toast.error(
@@ -61,9 +62,6 @@ function RouteComponent() {
           },
         }
       );
-
-      void navigate({ to: '/expenses' });
-      return;
     }
   };
 

--- a/src/app/routes/settings.account.tsx
+++ b/src/app/routes/settings.account.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import React from 'react';
 import { toast } from 'sonner';
 
@@ -13,6 +13,7 @@ export const Route = createFileRoute('/settings/account')({
 });
 
 function RouteComponent() {
+  const navigate = useNavigate();
   const updateMe = useUpdateMe();
   const { data, isError, error } = useMe();
 
@@ -60,6 +61,9 @@ function RouteComponent() {
           },
         }
       );
+
+      void navigate({ to: '/expenses' });
+      return;
     }
   };
 

--- a/src/app/routes/settings.index.tsx
+++ b/src/app/routes/settings.index.tsx
@@ -29,7 +29,6 @@ function RouteComponent() {
       settingItems: [
         {
           text: '내 정보 수정',
-          // to: '/settings/account',
         },
       ],
     },

--- a/src/app/routes/settings.index.tsx
+++ b/src/app/routes/settings.index.tsx
@@ -29,7 +29,7 @@ function RouteComponent() {
       settingItems: [
         {
           text: '내 정보 수정',
-          to: '/settings/account',
+          // to: '/settings/account',
         },
       ],
     },

--- a/src/shared/ui/SubmitButton/SubmitButton.tsx
+++ b/src/shared/ui/SubmitButton/SubmitButton.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@/components/ui/button';
 import { cn } from '@/shared/ui/styles/utils';
 
-export interface SubmitButtonProps {
+export interface SubmitButtonProps extends React.ComponentProps<'button'> {
   text: string;
-  state: 'default' | 'disabled';
-  onClick: () => void;
+  state?: 'default' | 'disabled';
+  onClick?: () => void;
   className?: React.ComponentProps<'button'>['className'] | undefined;
 }
 
@@ -13,6 +13,7 @@ const SubmitButton: React.FC<SubmitButtonProps> = ({
   state,
   onClick,
   className,
+  ...props
 }) => {
   return (
     <Button
@@ -24,6 +25,7 @@ const SubmitButton: React.FC<SubmitButtonProps> = ({
         state === 'disabled' && 'bg-[#ccc]',
         className
       )}
+      {...props}
     >
       {text}
     </Button>


### PR DESCRIPTION
- 소요시간: 1시간

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 사용자 정보 업데이트 후, 자동으로 경비 페이지로 이동하여 원활한 경험을 제공합니다.
  - 새로운 폼 관리 방식으로 사용자 닉네임과 이메일을 업데이트할 수 있습니다.
- **Bug Fixes**
  - 설정 메뉴의 “내 정보 수정” 항목 링크 기능이 비활성화되어, 원치 않는 화면 전환을 방지합니다.
- **기능 개선**
  - 제출 버튼이 표준 버튼 속성을 지원하며, 선택적 속성을 통해 유연성을 향상시켰습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->