### PR TITLE
SelectMonthDrawer를 MonthSelector에 추가, period를 useExpensesByPeriod의 queryKeys에 추가

### DIFF
--- a/src/features/expense/api/useExpenseQuery.ts
+++ b/src/features/expense/api/useExpenseQuery.ts
@@ -25,7 +25,7 @@ const baseUrl = apiUrl + '/expense/expenses/';
 const useExpensesByPeriod = (period: Period) => {
   const { year, month } = period;
   return useQuery<Expense[]>({
-    queryKey: queryKeys.expenses,
+    queryKey: [...queryKeys.expenses, period],
     queryFn: async () => {
       try {
         const res = await userAxios.get(baseUrl, {

--- a/src/features/expense/ui/MonthSelector/MonthSelector.tsx
+++ b/src/features/expense/ui/MonthSelector/MonthSelector.tsx
@@ -1,12 +1,6 @@
 import { Button } from '@/components/ui/button';
-import {
-  Drawer,
-  DrawerContent,
-  DrawerHeader,
-  DrawerTitle,
-  DrawerTrigger,
-} from '@/components/ui/drawer';
 import Period from '@/features/expense/model/types/Period';
+import SelectMonthDrawer from '@/features/expense/ui/SelectMonthDrawer';
 import ArrowLeftFilled from '@/shared/ui/icons/ArrowLeftFilled';
 import ArrowRightFilled from '@/shared/ui/icons/ArrowRightFilled';
 
@@ -48,24 +42,7 @@ const MonthSelector: React.FC<MonthSelectorProps> = ({
       >
         <ArrowLeftFilled size={16} color='#222' />
       </Button>
-      <Drawer>
-        <DrawerTrigger asChild>
-          <Button
-            variant='ghost'
-            className='h-auto p-0 text-[15px] rounded-none text-decoration-line: underline decoration-solid decoration-auto underline-offset-auto'
-            style={{ textUnderlinePosition: 'from-font' }}
-          >
-            {year !== new Date().getFullYear() && `${year.toString()}년 `}
-            {month}월
-          </Button>
-        </DrawerTrigger>
-        <DrawerContent className='flex items-center'>
-          <DrawerHeader>
-            <DrawerTitle>조회 월 선택</DrawerTitle>
-          </DrawerHeader>
-          <div className='p-4'>조회 월 선택 몸통</div>
-        </DrawerContent>
-      </Drawer>
+      <SelectMonthDrawer period={period} onSetPeriod={onSetPeriod} />
       <Button
         variant='ghost'
         size='icon'

--- a/src/features/expense/ui/SelectMonthDrawer/SelectMonthDrawer.test.tsx
+++ b/src/features/expense/ui/SelectMonthDrawer/SelectMonthDrawer.test.tsx
@@ -1,33 +1,52 @@
 import { fireEvent, render } from '@testing-library/react';
 import { describe, it, vi } from 'vitest';
 
+import Period from '@/features/expense/model/types/Period';
+
 import SelectMonthDrawer, { SelectMonthDrawerProps } from './SelectMonthDrawer';
 
 describe('SelectMonthDrawer', () => {
+  const current = new Date();
+  const currentPeriod: Period = {
+    year: current.getFullYear(),
+    month: current.getMonth() + 1,
+  };
+
   const props: SelectMonthDrawerProps = {
-    trigger: 'trigger-text',
-    period: { year: 2025, month: 1 },
+    period: { ...currentPeriod },
     onSetPeriod: vi.fn(),
   };
 
-  const renderElement = ({
-    trigger,
-    period,
-    onSetPeriod,
-  }: SelectMonthDrawerProps) =>
-    render(
-      <SelectMonthDrawer
-        trigger={trigger}
-        period={period}
-        onSetPeriod={onSetPeriod}
-      />
-    );
+  const renderElement = ({ period, onSetPeriod }: SelectMonthDrawerProps) =>
+    render(<SelectMonthDrawer period={period} onSetPeriod={onSetPeriod} />);
 
-  it('renders drawer trigger.', () => {
-    const { getByRole } = renderElement({ ...props });
+  describe('drawer trigger', () => {
+    it('when period year is current year, renders month.', () => {
+      const { getByRole } = renderElement({
+        ...props,
+      });
 
-    const trigger = getByRole('button');
-    expect(trigger).toBeInTheDocument();
+      const trigger = getByRole('button');
+      expect(trigger).toBeInTheDocument();
+      expect(trigger).toHaveTextContent(props.period.month.toString() + '월');
+    });
+
+    it('when period year is not current year, renders year + month.', () => {
+      const newPeriod: Period = {
+        ...currentPeriod,
+        year: currentPeriod.year - 1,
+      };
+      const { getByRole } = renderElement({
+        ...props,
+        period: { ...newPeriod },
+      });
+
+      const trigger = getByRole('button');
+      expect(trigger).toBeInTheDocument();
+      expect(trigger).toHaveTextContent(
+        `${newPeriod.year.toString()}년 ${props.period.month.toString()}월`
+      );
+    });
   });
 
   it('when trigger button is clicked, renders title and close button.', () => {
@@ -47,7 +66,7 @@ describe('SelectMonthDrawer', () => {
     expect(title.tagName.toLowerCase()).toBe('h2');
 
     const closeButton = getByLabelText('close button');
-    expect(closeButton.tagName.toLowerCase()).toBe('button');
+    expect(closeButton).toBeInTheDocument();
   });
 
   it('when month is selected, calls onSetPeriod with selected period.', () => {

--- a/src/features/expense/ui/SelectMonthDrawer/SelectMonthDrawer.tsx
+++ b/src/features/expense/ui/SelectMonthDrawer/SelectMonthDrawer.tsx
@@ -1,5 +1,6 @@
 import { X } from 'lucide-react';
 
+import { Button } from '@/components/ui/button';
 import {
   Drawer,
   DrawerClose,
@@ -13,19 +14,27 @@ import Period from '@/features/expense/model/types/Period';
 import SelectMonthList from '../SelectMonthList';
 
 export interface SelectMonthDrawerProps {
-  trigger: React.ReactNode;
   period: Period;
   onSetPeriod: (newPeriod: Period) => void;
 }
 
 const SelectMonthDrawer: React.FC<SelectMonthDrawerProps> = ({
-  trigger,
   period,
   onSetPeriod,
 }) => {
+  const { year, month } = period;
   return (
     <Drawer>
-      <DrawerTrigger>{trigger}</DrawerTrigger>
+      <DrawerTrigger asChild>
+        <Button
+          variant='ghost'
+          className='h-auto p-0 text-[15px] rounded-none text-decoration-line: underline decoration-solid decoration-auto underline-offset-auto'
+          style={{ textUnderlinePosition: 'from-font' }}
+        >
+          {year !== new Date().getFullYear() && `${year.toString()}년 `}
+          {month}월
+        </Button>
+      </DrawerTrigger>
       <DrawerContent
         className='w-full max-w-sm mx-auto py-6 px-5'
         style={{ borderRadius: '20px 20px 0 0 ' }}


### PR DESCRIPTION
- 소요시간: 30분
- SelectMonthDrawer를 MonthSelector에 추가
- SelectMonthDrawer 테스트 코드 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 월 선택 인터페이스가 간소화되어, 직관적인 버튼을 통해 월 선택이 용이해졌습니다. 필요 시 연도 정보도 함께 표시됩니다.

- **테스트**
  - 월 표시 및 버튼 동작에 대한 테스트 케이스가 추가되어, 현재 연도와 다른 연도에 대한 올바른 정보 표시를 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->