### PR TITLE
Fix: /expenses/new 에서 카테고리 선택시 기존 입력값 날라가는 문제 해결

### DIFF
--- a/src/app/routes/expenses.$uid.categories.index.tsx
+++ b/src/app/routes/expenses.$uid.categories.index.tsx
@@ -11,10 +11,7 @@ import {
 import { Category } from '@/features/category/model/types/Category';
 import CategoryTag from '@/features/category/ui/CategoryTag';
 import InputCategoryTags from '@/features/category/ui/InputCategoryTags';
-import {
-  useExpenseByUid,
-  useUpdateExpense,
-} from '@/features/expense/api/useExpenseQuery';
+import { useNewExpenseByUid } from '@/features/expense/api/useExpenseQuery';
 import Ellipsis from '@/shared/ui/icons/Ellipsis';
 import Layout from '@/shared/ui/layout/Layout';
 import SubPageHeader from '@/shared/ui/SubPageHeader';
@@ -28,15 +25,14 @@ export function ExpenseUidCategoriesRoute() {
   const { uid }: { uid: string } = Route.useParams();
 
   const addCategory = useAddCategory();
-  const updateExpense = useUpdateExpense();
-  const { data: expense, isLoading: isExpenseLoading } = useExpenseByUid(uid);
+  const { newExpense, updateNewExpenseCategories } = useNewExpenseByUid(uid);
   const { categories, isLoading, isError, error } = useCategories();
 
   const [values, setValues] = React.useState<string[]>(
-    expense ? expense.categories.map((category) => category.name) : []
+    newExpense.categories.map((category) => category.name)
   );
 
-  if (isLoading || isExpenseLoading) {
+  if (isLoading) {
     return <>Loading</>;
   }
 
@@ -79,13 +75,7 @@ export function ExpenseUidCategoriesRoute() {
     const selectedCategories =
       categories?.filter((category) => values.includes(category.name)) ?? [];
 
-    if (expense) {
-      updateExpense.mutate({ ...expense, categories: selectedCategories });
-    } else {
-      toast.error('지출 정보를 가져오지 못했어요.');
-      return;
-    }
-
+    updateNewExpenseCategories(selectedCategories);
     void navigate({ to: `/expenses/${uid}` });
   };
 

--- a/src/app/routes/expenses.$uid.index.tsx
+++ b/src/app/routes/expenses.$uid.index.tsx
@@ -54,7 +54,7 @@ export function RouteComponent() {
   return (
     <Layout guarded>
       <SubPageHeader title='지출 내역 수정' back onClose={handleDelete} />
-      <ExpenseForm uid={uid} expense={expense} />
+      <ExpenseForm expense={expense} />
     </Layout>
   );
 }

--- a/src/app/routes/expenses.$uid.index.tsx
+++ b/src/app/routes/expenses.$uid.index.tsx
@@ -19,7 +19,7 @@ export function RouteComponent() {
   const deleteExpense = useDeleteExpense();
 
   const { uid }: { uid: string } = Route.useParams();
-  const { data: expense, isLoading, isError, error } = useExpenseByUid(uid);
+  const { data: expense, isLoading, isError } = useExpenseByUid(uid);
   const { newExpense, updateNewExpense } = useNewExpenseByUid(uid);
 
   if (isLoading) {

--- a/src/app/routes/expenses.$uid.index.tsx
+++ b/src/app/routes/expenses.$uid.index.tsx
@@ -33,7 +33,13 @@ export function RouteComponent() {
     );
   }
 
-  if (isError || !expense) {
+  if (isError) {
+    toast.error('해당 지출내역을 찾을 수 없어요.');
+    void navigate({ to: '/expenses' });
+    return;
+  }
+
+  if (!expense) {
     toast.error('해당 지출내역을 찾을 수 없어요.');
     void navigate({ to: '/expenses' });
     return;

--- a/src/app/routes/expenses.$uid.index.tsx
+++ b/src/app/routes/expenses.$uid.index.tsx
@@ -33,12 +33,10 @@ export function RouteComponent() {
     );
   }
 
-  if (isError) {
-    throw error;
-  }
-
-  if (!expense) {
-    throw new Error('Expense not found');
+  if (isError || !expense) {
+    toast.error('해당 지출내역을 찾을 수 없어요.');
+    void navigate({ to: '/expenses' });
+    return;
   }
 
   updateNewExpense(expense);

--- a/src/app/routes/expenses.$uid.index.tsx
+++ b/src/app/routes/expenses.$uid.index.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 import {
   useDeleteExpense,
   useExpenseByUid,
+  useNewExpenseByUid,
 } from '@/features/expense/api/useExpenseQuery';
 import ExpenseForm from '@/features/expense/ui/ExpenseForm';
 import Layout from '@/shared/ui/layout/Layout';
@@ -19,6 +20,7 @@ export function RouteComponent() {
 
   const { uid }: { uid: string } = Route.useParams();
   const { data: expense, isLoading, isError, error } = useExpenseByUid(uid);
+  const { newExpense, updateNewExpense } = useNewExpenseByUid(uid);
 
   if (isLoading) {
     return (
@@ -39,6 +41,8 @@ export function RouteComponent() {
     throw new Error('Expense not found');
   }
 
+  updateNewExpense(expense);
+
   const handleDelete = () => {
     deleteExpense.mutate(uid, {
       onSuccess: () => {
@@ -54,7 +58,7 @@ export function RouteComponent() {
   return (
     <Layout guarded>
       <SubPageHeader title='지출 내역 수정' back onClose={handleDelete} />
-      <ExpenseForm expense={expense} />
+      <ExpenseForm expense={newExpense} />
     </Layout>
   );
 }

--- a/src/app/routes/expenses.new.categories.index.tsx
+++ b/src/app/routes/expenses.new.categories.index.tsx
@@ -11,7 +11,7 @@ import {
 import { Category } from '@/features/category/model/types/Category';
 import CategoryTag from '@/features/category/ui/CategoryTag';
 import InputCategoryTags from '@/features/category/ui/InputCategoryTags';
-import { useNewExpense } from '@/features/expense/api/useExpenseQuery';
+import { useNewExpenseByUid } from '@/features/expense/api/useExpenseQuery';
 import Ellipsis from '@/shared/ui/icons/Ellipsis';
 import Layout from '@/shared/ui/layout/Layout';
 import SubPageHeader from '@/shared/ui/SubPageHeader';
@@ -24,7 +24,7 @@ export function NewCategoriesRoute() {
   const navigate = useNavigate();
   const addCategory = useAddCategory();
 
-  const { newExpense, updateNewExpenseCategories } = useNewExpense();
+  const { newExpense, updateNewExpenseCategories } = useNewExpenseByUid('new');
   const { categories, isLoading, isError, error } = useCategories();
 
   const [values, setValues] = React.useState<string[]>(

--- a/src/app/routes/expenses.new.index.tsx
+++ b/src/app/routes/expenses.new.index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 
-import { useNewExpense } from '@/features/expense/api/useExpenseQuery';
+import { useNewExpenseByUid } from '@/features/expense/api/useExpenseQuery';
 import ExpenseForm from '@/features/expense/ui/ExpenseForm';
 import Layout from '@/shared/ui/layout/Layout';
 import SubPageHeader from '@/shared/ui/SubPageHeader';
@@ -10,7 +10,8 @@ export const Route = createFileRoute('/expenses/new/')({
 });
 
 export function RouteComponent() {
-  const { newExpense } = useNewExpense();
+  const { newExpense } = useNewExpenseByUid('new');
+
   return (
     <Layout guarded>
       <SubPageHeader title='지출 내역 추가' back />

--- a/src/features/expense/api/useExpenseQuery.ts
+++ b/src/features/expense/api/useExpenseQuery.ts
@@ -219,7 +219,7 @@ const useNewExpenseByUid = (uid: string) => {
       ]);
 
       if (previousData === undefined) {
-        throw new Error('error useNewExpenseByUid');
+        throw new Error('error useNewExpenseByUid: ' + uid);
       }
 
       return { ...previousData };

--- a/src/features/expense/api/useExpenseQuery.ts
+++ b/src/features/expense/api/useExpenseQuery.ts
@@ -212,7 +212,18 @@ const useNewExpenseByUid = (uid: string) => {
 
   const { data: newExpense } = useQuery<Expense>({
     queryKey: ['newExpense', uid],
-    queryFn: () => Promise.resolve({ ...initialData, uid }),
+    queryFn: () => {
+      const previousData = queryClient.getQueryData<Expense>([
+        'newExpense',
+        uid,
+      ]);
+
+      if (previousData === undefined) {
+        throw new Error('error useNewExpenseByUid');
+      }
+
+      return { ...previousData };
+    },
     enabled: false,
     initialData: { ...initialData, uid },
   });

--- a/src/features/expense/api/useExpenseQuery.ts
+++ b/src/features/expense/api/useExpenseQuery.ts
@@ -234,43 +234,28 @@ const useNewExpenseByUid = (uid: string) => {
     });
   };
 
-  const updateNewExpenseField = <K extends keyof Omit<Expense, 'uid'>>(
+  const updateNewExpenseField = <K extends keyof Expense>(
     key: K,
-    value: Omit<Expense, 'uid'>[K]
+    value: Expense[K]
   ) => {
     return queryClient.setQueryData<Expense>(
       ['newExpense', uid],
       (oldExpense) => {
         return oldExpense !== undefined
-          ? { ...oldExpense, uid, [key]: value }
+          ? { ...oldExpense, [key]: value }
           : { ...initialData, uid, [key]: value };
       }
     );
-  };
-
-  const updateNewExpenseDate = (date: Date) => {
-    return updateNewExpenseField('date', date);
-  };
-
-  const updateNewExpenseMemo = (memo: string) => {
-    return updateNewExpenseField('memo', memo);
   };
 
   const updateNewExpenseCategories = (categories: Category[]) => {
     return updateNewExpenseField('categories', categories);
   };
 
-  const updateNewExpenseAmount = (amount: number) => {
-    return updateNewExpenseField('amount', amount);
-  };
-
   return {
     newExpense,
     updateNewExpense,
-    updateNewExpenseDate,
-    updateNewExpenseMemo,
     updateNewExpenseCategories,
-    updateNewExpenseAmount,
   };
 };
 

--- a/src/features/expense/api/useExpenseQuery.ts
+++ b/src/features/expense/api/useExpenseQuery.ts
@@ -200,42 +200,39 @@ const useTotalAmountByPeriod = (period: Period) => {
   return { totalAmount, isLoading, error };
 };
 
-const initialOmittedExpense: Omit<Expense, 'uid'> = {
+const initialData: Omit<Expense, 'uid'> = {
   date: new Date(),
   memo: '',
   categories: [],
   amount: 0,
 };
 
-const useNewExpense = () => {
+const useNewExpenseByUid = (uid: string) => {
   const queryClient = useQueryClient();
 
-  const { data: newExpense } = useQuery<Omit<Expense, 'uid'>>({
-    queryKey: ['newExpense'],
-    queryFn: () => Promise.resolve(initialOmittedExpense),
+  const { data: newExpense } = useQuery<Expense>({
+    queryKey: ['newExpense', uid],
+    queryFn: () => Promise.resolve({ ...initialData, uid }),
     enabled: false,
-    initialData: initialOmittedExpense,
+    initialData: { ...initialData, uid },
   });
 
-  const updateNewExpense = (expense: Omit<Expense, 'uid'>) => {
-    return queryClient.setQueryData<Omit<Expense, 'uid'>>(
-      ['newExpense'],
-      () => {
-        return expense;
-      }
-    );
+  const updateNewExpense = (expense: Expense) => {
+    return queryClient.setQueryData<Expense>(['newExpense', uid], () => {
+      return expense;
+    });
   };
 
   const updateNewExpenseField = <K extends keyof Omit<Expense, 'uid'>>(
     key: K,
     value: Omit<Expense, 'uid'>[K]
   ) => {
-    return queryClient.setQueryData<Omit<Expense, 'uid'>>(
-      ['newExpense'],
+    return queryClient.setQueryData<Expense>(
+      ['newExpense', uid],
       (oldExpense) => {
         return oldExpense !== undefined
-          ? { ...oldExpense, [key]: value }
-          : { ...initialOmittedExpense, [key]: value };
+          ? { ...oldExpense, uid, [key]: value }
+          : { ...initialData, uid, [key]: value };
       }
     );
   };
@@ -272,7 +269,7 @@ export {
   useDeleteExpense,
   useExpenseByUid,
   useExpensesByPeriod,
-  useNewExpense,
+  useNewExpenseByUid,
   useTotalAmountByPeriod,
   useUpdateExpense,
 };

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -78,7 +78,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense }) => {
     updateNewExpense({ uid: expense.uid, date, memo, categories, amount });
   };
 
-  const isDisabledSubmit = () => {
+  const disabled = React.useMemo(() => {
     if (memo.length === 0 || memo.length > 120) {
       return true;
     }
@@ -92,7 +92,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense }) => {
     }
 
     return false;
-  };
+  }, [memo, categories, amount]);
 
   const handleOnSubmit = (values: Omit<Expense, 'uid'>) => {
     if (expense.uid === 'new') {
@@ -286,7 +286,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense }) => {
         <Button
           type='submit'
           className='h-13 text-[15px] font-semibold mt-auto mb-5 rounded-full'
-          disabled={isDisabledSubmit()}
+          disabled={disabled}
         >
           저장
         </Button>

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -95,21 +95,42 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense }) => {
   };
 
   const handleOnSubmit = (values: Omit<Expense, 'uid'>) => {
-    if (expense.uid !== 'new') {
-      updateExpense.mutate({ uid: expense.uid, ...values });
+    if (expense.uid === 'new') {
+      addExpense.mutate(
+        { ...values },
+        {
+          onSuccess: () => {
+            toast.success('지출내역을 추가했어요.');
+            void navigate({ to: '/expenses' });
+          },
+          onError: () => {
+            toast.error('지출내역을 추가하는데 실패했어요.');
+          },
+        }
+      );
+      return;
     } else {
-      addExpense.mutate({ ...values });
+      updateExpense.mutate(
+        { uid: expense.uid, ...values },
+        {
+          onSuccess: () => {
+            toast.success('지출내역을 수정했어요.');
+            void navigate({ to: '/expenses' });
+          },
+          onError: () => {
+            toast.error('지출내역을 추가하는데 실패했어요.');
+          },
+        }
+      );
     }
 
     updateNewExpense({
-      uid: 'new',
+      uid: expense.uid,
       date: new Date(),
       memo: '',
       amount: 0,
       categories: [],
     });
-
-    void navigate({ to: '/expenses' });
   };
 
   return (

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -55,7 +55,6 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense }) => {
   const addExpense = useAddExpense();
   const { updateNewExpense } = useNewExpenseByUid(expense.uid);
 
-  const [disabled, setDisabled] = React.useState<boolean>(true);
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   const form = useForm<Omit<Expense, 'uid'>>({
@@ -75,17 +74,24 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense }) => {
   const categories = watch('categories');
   const amount = watch('amount');
 
-  React.useEffect(() => {
-    if (memo !== '' && categories.length > 0 && amount !== 0) {
-      setDisabled(false);
-      return;
-    }
-
-    setDisabled(true);
-  }, [memo, categories, amount, setDisabled]);
-
   const handleClickCategory = () => {
     updateNewExpense({ uid: expense.uid, date, memo, categories, amount });
+  };
+
+  const isDisabledSubmit = () => {
+    if (memo.length === 0 || memo.length > 120) {
+      return true;
+    }
+
+    if (categories.length === 0 || categories.length > 3) {
+      return true;
+    }
+
+    if (amount === 0 || !amount) {
+      return true;
+    }
+
+    return false;
   };
 
   const handleOnSubmit = (values: Omit<Expense, 'uid'>) => {
@@ -280,7 +286,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense }) => {
         <Button
           type='submit'
           className='h-13 text-[15px] font-semibold mt-auto mb-5 rounded-full'
-          disabled={disabled}
+          disabled={isDisabledSubmit()}
         >
           저장
         </Button>

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -116,7 +116,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense }) => {
             void navigate({ to: '/expenses' });
           },
           onError: () => {
-            toast.error('지출내역을 추가하는데 실패했어요.');
+            toast.error('지출내역을 수정하는데 실패했어요.');
           },
         }
       );

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -1,10 +1,8 @@
-import { zodResolver } from '@hookform/resolvers/zod';
 import { Link, useNavigate } from '@tanstack/react-router';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import { NumberFormatValues, NumericFormat } from 'react-number-format';
 import { toast } from 'sonner';
-import { z } from 'zod';
 
 import { Button, buttonVariants } from '@/components/ui/button';
 import {

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -99,6 +99,14 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense }) => {
         {
           onSuccess: () => {
             toast.success('지출내역을 추가했어요.');
+            updateNewExpense({
+              uid: expense.uid,
+              date: new Date(),
+              memo: '',
+              amount: 0,
+              categories: [],
+            });
+
             void navigate({ to: '/expenses' });
           },
           onError: () => {
@@ -113,6 +121,14 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense }) => {
         {
           onSuccess: () => {
             toast.success('지출내역을 수정했어요.');
+            updateNewExpense({
+              uid: expense.uid,
+              date: new Date(),
+              memo: '',
+              amount: 0,
+              categories: [],
+            });
+
             void navigate({ to: '/expenses' });
           },
           onError: () => {
@@ -121,14 +137,6 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense }) => {
         }
       );
     }
-
-    updateNewExpense({
-      uid: expense.uid,
-      date: new Date(),
-      memo: '',
-      amount: 0,
-      categories: [],
-    });
   };
 
   return (

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -76,10 +76,6 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense }) => {
   const amount = watch('amount');
 
   React.useEffect(() => {
-    updateNewExpense(expense);
-  }, [expense, updateNewExpense]);
-
-  React.useEffect(() => {
     if (memo !== '' && categories.length > 0 && amount !== 0) {
       setDisabled(false);
       return;


### PR DESCRIPTION
- 소요시간: 3시간
- ExpenseForm 구조 변경
- useNewExpense를 useNewExpenseByUid 로 구조 변경
- related to tc_043, tc_044
  - 지출내역 추가시 작업 정상작동 확인
  - 지출내역 수정시 작업 필요 (추후 PR 에서 작업)
![image](https://github.com/user-attachments/assets/a151770a-4a81-4f0f-af43-089dfda7a551)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - 비용 데이터 관리 방식을 통합하여 로딩 상태 처리와 상태 초기화가 간소화되었습니다.
  - 비용 양식의 제출 로직이 단순화되어 사용자 경험이 개선되었습니다.

- **Bug Fixes / Improvements**
  - 오류 발생 시 토스트 알림과 원활한 페이지 전환으로 피드백을 강화하였습니다.
  - 비용 등록 양식의 버튼 텍스트가 항상 "저장"으로 일관되게 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->