### PR TITLE
getMe 로직 수정

### DIFF
--- a/src/app/routes/login.index.tsx
+++ b/src/app/routes/login.index.tsx
@@ -18,6 +18,7 @@ export const Route = createFileRoute('/login/')({
       return redirect({ to: '/expenses' });
     } catch {
       localStorage.removeItem(TOKEN_KEY);
+      return;
     }
   },
   component: RouteComponent,

--- a/src/app/routes/login.index.tsx
+++ b/src/app/routes/login.index.tsx
@@ -1,19 +1,29 @@
-import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 
 import { TOKEN_KEY } from '@/constants';
 import SignInButton from '@/features/auth/ui/SignInButton';
+import { apiUrl } from '@/features/common/consts';
+import userAxios from '@/shared/api/userAxios';
 import Layout from '@/shared/ui/layout/Layout';
 
 export const Route = createFileRoute('/login/')({
+  loader: async () => {
+    try {
+      const res = await userAxios.get(`${apiUrl}/account/users/me`);
+      if (res.status !== 200) {
+        localStorage.removeItem(TOKEN_KEY);
+        return;
+      }
+
+      return redirect({ to: '/expenses' });
+    } catch {
+      localStorage.removeItem(TOKEN_KEY);
+    }
+  },
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  const navigate = useNavigate();
-  if (localStorage.getItem(TOKEN_KEY)) {
-    void navigate({ to: '/expenses' });
-  }
-
   return (
     <Layout>
       <div className='flex flex-col gap-3 w-full px-5 mt-auto'>

--- a/src/shared/ui/layout/Layout.tsx
+++ b/src/shared/ui/layout/Layout.tsx
@@ -10,7 +10,7 @@ const Layout: React.FC<{
   guarded?: boolean;
 }> = ({ children, isLoading, guarded }) => {
   const navigate = useNavigate();
-  const { isLoading: isMeLoading, isError } = useMe();
+  const { isError } = useMe();
 
   if (!guarded) {
     return (
@@ -20,21 +20,14 @@ const Layout: React.FC<{
     );
   }
 
-  const token = localStorage.getItem(TOKEN_KEY);
-
-  if (!token) {
-    toast.error('소셜 로그인에서 문제가 발생했어요.');
-    void navigate({ to: '/login' });
-    return;
-  }
-
   if (isError) {
+    localStorage.removeItem(TOKEN_KEY);
     toast.error('소셜 로그인에서 문제가 발생했어요.');
     void navigate({ to: '/login' });
     return;
   }
 
-  if (isLoading || isMeLoading) {
+  if (isLoading) {
     return (
       <div className='container mx-auto h-screen bg-white relative flex flex-col overflow-hidden safe-area-wrapper'>
         <div className='flex flex-1 justify-center items-center'>


### PR DESCRIPTION
- 소요시간: 20분
- 로그인 페이지에서 get-me 실패시 토큰을 로컬스토리지에서 삭제
- guarded Layout에서 useMe 실패시 페이지 이동 및 토큰 삭제. useMe 로딩시 loader 반환하는 기능 제거.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- 로그인 시 비동기 인증 검증이 추가되어, 인증이 성공되면 자동으로 주요 페이지로 이동합니다.
- **버그 수정**
	- 오류 발생 시 토큰을 로컬 스토리지에서 제거하고 로그인 페이지로 리다이렉션하는 로직이 개선되었습니다.
- **리팩토링**
	- 불필요한 상태 체크를 제거하고, 오류 발생 시 보다 명확한 안내와 안정적인 리다이렉션이 이루어지도록 인터페이스 흐름을 개선하였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->