### PR TITLE
SubPageHeader 리팩토링 및 페이지 이동 액션 수정

### DIFF
--- a/src/app/routes.custom.tsx
+++ b/src/app/routes.custom.tsx
@@ -25,7 +25,7 @@ const termsRoute = createRoute({
   path: 'terms.html',
   component: () => (
     <>
-      <SubPageHeader title='이용약관' back />
+      <SubPageHeader title='이용약관' />
       <TermsPage />
     </>
   ),
@@ -36,7 +36,7 @@ const privacyRoute = createRoute({
   path: 'privacy.html',
   component: () => (
     <>
-      <SubPageHeader title='개인정보 처리방침' back />
+      <SubPageHeader title='개인정보 처리방침' />
       <PrivacyPage />
     </>
   ),

--- a/src/app/routes.custom.tsx
+++ b/src/app/routes.custom.tsx
@@ -1,5 +1,5 @@
 // routes.custom.ts
-import { createRoute, Outlet } from '@tanstack/react-router';
+import { createRoute, Outlet, redirect } from '@tanstack/react-router';
 
 import PrivacyPage from '@/pages/about/agreements/PrivacyPage';
 import TermsPage from '@/pages/about/agreements/TermsPage';
@@ -25,7 +25,12 @@ const termsRoute = createRoute({
   path: 'terms.html',
   component: () => (
     <>
-      <SubPageHeader title='이용약관' />
+      <SubPageHeader
+        title='이용약관'
+        onClickBack={() => {
+          void redirect({ to: '/settings' });
+        }}
+      />
       <TermsPage />
     </>
   ),
@@ -36,7 +41,12 @@ const privacyRoute = createRoute({
   path: 'privacy.html',
   component: () => (
     <>
-      <SubPageHeader title='개인정보 처리방침' />
+      <SubPageHeader
+        title='개인정보 처리방침'
+        onClickBack={() => {
+          void redirect({ to: '/settings' });
+        }}
+      />
       <PrivacyPage />
     </>
   ),

--- a/src/app/routes/expenses.$uid.categories.index.tsx
+++ b/src/app/routes/expenses.$uid.categories.index.tsx
@@ -82,7 +82,12 @@ export function ExpenseUidCategoriesRoute() {
 
   return (
     <UserLayout>
-      <SubPageHeader title='카테고리 설정' close />
+      <SubPageHeader
+        title='카테고리 설정'
+        onClose={() => {
+          void navigate({ to: '/expenses/$uid', params: { uid } });
+        }}
+      />
       <div className='mt-6 px-5'>
         <InputCategoryTags
           value={values}

--- a/src/app/routes/expenses.$uid.index.tsx
+++ b/src/app/routes/expenses.$uid.index.tsx
@@ -25,7 +25,7 @@ export function RouteComponent() {
   if (isLoading) {
     return (
       <UserLayout>
-        <SubPageHeader title='지출 내역 수정' back />
+        <SubPageHeader title='지출 내역 수정' />
         <div className='flex flex-1 justify-center items-center'>
           <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-[#222]' />
         </div>
@@ -61,7 +61,13 @@ export function RouteComponent() {
 
   return (
     <UserLayout>
-      <SubPageHeader title='지출 내역 수정' back onDelete={handleDelete} />
+      <SubPageHeader
+        title='지출 내역 수정'
+        onClickBack={() => {
+          void navigate({ to: '/expenses' });
+        }}
+        onDelete={handleDelete}
+      />
       <ExpenseForm expense={newExpense} />
     </UserLayout>
   );

--- a/src/app/routes/expenses.$uid.index.tsx
+++ b/src/app/routes/expenses.$uid.index.tsx
@@ -61,7 +61,7 @@ export function RouteComponent() {
 
   return (
     <UserLayout>
-      <SubPageHeader title='지출 내역 수정' back onClose={handleDelete} />
+      <SubPageHeader title='지출 내역 수정' back onDelete={handleDelete} />
       <ExpenseForm expense={newExpense} />
     </UserLayout>
   );

--- a/src/app/routes/expenses.new.categories.index.tsx
+++ b/src/app/routes/expenses.new.categories.index.tsx
@@ -83,7 +83,12 @@ export function NewCategoriesRoute() {
 
   return (
     <UserLayout>
-      <SubPageHeader title='카테고리 설정' close />
+      <SubPageHeader
+        title='카테고리 설정'
+        onClose={() => {
+          void navigate({ to: '/expenses/new' });
+        }}
+      />
       <div className='mt-6 px-5'>
         <InputCategoryTags
           value={values}

--- a/src/app/routes/expenses.new.index.tsx
+++ b/src/app/routes/expenses.new.index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
 
 import { useNewExpenseByUid } from '@/features/expense/api/useExpenseQuery';
 import ExpenseForm from '@/features/expense/ui/ExpenseForm';
@@ -10,11 +10,17 @@ export const Route = createFileRoute('/expenses/new/')({
 });
 
 export function RouteComponent() {
+  const navigate = useNavigate();
   const { newExpense } = useNewExpenseByUid('new');
 
   return (
     <UserLayout>
-      <SubPageHeader title='지출 내역 추가' back />
+      <SubPageHeader
+        title='지출 내역 추가'
+        onClickBack={() => {
+          void navigate({ to: '/expenses' });
+        }}
+      />
       <ExpenseForm expense={newExpense} />
     </UserLayout>
   );

--- a/src/app/routes/settings.account.tsx
+++ b/src/app/routes/settings.account.tsx
@@ -92,7 +92,12 @@ function RouteComponent() {
 
   return (
     <UserLayout>
-      <SubPageHeader title='회원정보' back />
+      <SubPageHeader
+        title='회원정보'
+        onClickBack={() => {
+          void navigate({ to: '/settings' });
+        }}
+      />
       <Form {...form}>
         <form
           className='flex flex-col flex-1 pt-6 pb-8 px-5'

--- a/src/app/routes/settings.index.tsx
+++ b/src/app/routes/settings.index.tsx
@@ -72,7 +72,12 @@ function RouteComponent() {
 
   return (
     <UserLayout>
-      <SubPageHeader title='설정' back />
+      <SubPageHeader
+        title='설정'
+        onClickBack={() => {
+          void navigate({ to: '/expenses' });
+        }}
+      />
       <ul className='flex flex-col list-none gap-6 pt-6 px-5'>
         {settingGroups.map((settingGroup) => (
           <li className='flex flex-col gap-4' key={settingGroup.text}>

--- a/src/features/category/ui/routes/CategoriesRoute/CategoriesRoute.tsx
+++ b/src/features/category/ui/routes/CategoriesRoute/CategoriesRoute.tsx
@@ -68,7 +68,7 @@ const CategoriesRoute: React.FC<CategoriesRouteProps> = ({ uid }) => {
 
   return (
     <UserLayout>
-      <SubPageHeader title='카테고리 설정' close />
+      <SubPageHeader title='카테고리 설정' />
       <div className='mt-6 px-5'>
         <InputCategoryTags
           value={inputCategories}

--- a/src/features/category/ui/routes/CategoryRoute/CategoryRoute.tsx
+++ b/src/features/category/ui/routes/CategoryRoute/CategoryRoute.tsx
@@ -118,7 +118,17 @@ const CategoryRoute: React.FC = () => {
 
   return (
     <UserLayout>
-      <SubPageHeader title='카테고리명 편집' close />
+      <SubPageHeader
+        title='카테고리명 편집'
+        onClose={() => {
+          if (uid) {
+            void navigate({ to: '/expenses/$uid', params: { uid } });
+            return;
+          }
+
+          void navigate({ to: '/expenses/new' });
+        }}
+      />
       <Form {...form}>
         <form
           // eslint-disable-next-line @typescript-eslint/no-misused-promises

--- a/src/shared/ui/SubPageHeader/SubPageHeader.tsx
+++ b/src/shared/ui/SubPageHeader/SubPageHeader.tsx
@@ -19,6 +19,7 @@ export interface SubPageHeaderProps {
   title: string;
   back?: boolean;
   close?: boolean;
+  onClickBack?: () => void;
   onClose?: () => void;
   onDelete?: () => void;
 }
@@ -27,6 +28,7 @@ const SubPageHeader: React.FC<SubPageHeaderProps> = ({
   title,
   back,
   close,
+  onClickBack,
   onClose,
   onDelete,
 }) => {
@@ -58,6 +60,19 @@ const SubPageHeader: React.FC<SubPageHeaderProps> = ({
           onClick={() => {
             handleClickBack();
           }}
+        >
+          <ArrowLeft size={24} />
+        </div>
+      )}
+      {onClickBack && (
+        <div
+          aria-label='back button'
+          role='button'
+          className={cn(
+            buttonVariants({ variant: 'ghost' }),
+            'absolute left-5 size-6'
+          )}
+          onClick={onClickBack}
         >
           <ArrowLeft size={24} />
         </div>

--- a/src/shared/ui/SubPageHeader/SubPageHeader.tsx
+++ b/src/shared/ui/SubPageHeader/SubPageHeader.tsx
@@ -17,7 +17,6 @@ import { cn } from '@/shared/ui/styles/utils';
 
 export interface SubPageHeaderProps {
   title: string;
-  back?: boolean;
   close?: boolean;
   onClickBack?: () => void;
   onClose?: () => void;
@@ -26,17 +25,12 @@ export interface SubPageHeaderProps {
 
 const SubPageHeader: React.FC<SubPageHeaderProps> = ({
   title,
-  back,
   close,
   onClickBack,
   onClose,
   onDelete,
 }) => {
   const router = useRouter();
-
-  const handleClickBack = () => {
-    router.history.back();
-  };
 
   const handleClickClose = () => {
     if (!onClose) {
@@ -49,21 +43,6 @@ const SubPageHeader: React.FC<SubPageHeaderProps> = ({
 
   return (
     <header className='flex flex-row justify-center items-center h-14 px-5 py-4'>
-      {back && (
-        <div
-          aria-label='back button'
-          role='button'
-          className={cn(
-            buttonVariants({ variant: 'ghost' }),
-            'absolute left-5 size-6'
-          )}
-          onClick={() => {
-            handleClickBack();
-          }}
-        >
-          <ArrowLeft size={24} />
-        </div>
-      )}
       {onClickBack && (
         <div
           aria-label='back button'

--- a/src/shared/ui/SubPageHeader/SubPageHeader.tsx
+++ b/src/shared/ui/SubPageHeader/SubPageHeader.tsx
@@ -20,6 +20,7 @@ export interface SubPageHeaderProps {
   back?: boolean;
   close?: boolean;
   onClose?: () => void;
+  onDelete?: () => void;
 }
 
 const SubPageHeader: React.FC<SubPageHeaderProps> = ({
@@ -27,6 +28,7 @@ const SubPageHeader: React.FC<SubPageHeaderProps> = ({
   back,
   close,
   onClose,
+  onDelete,
 }) => {
   const router = useRouter();
 
@@ -76,7 +78,7 @@ const SubPageHeader: React.FC<SubPageHeaderProps> = ({
           <X size={24} />
         </div>
       )}
-      {onClose && (
+      {onDelete && (
         <Drawer>
           <DrawerTrigger asChild>
             <Button
@@ -99,7 +101,7 @@ const SubPageHeader: React.FC<SubPageHeaderProps> = ({
               </DrawerDescription>
             </DrawerHeader>
             <DrawerFooter className='p-0 mt-9'>
-              <Button className='h-13 rounded-full' onClick={handleClickClose}>
+              <Button className='h-13 rounded-full' onClick={onDelete}>
                 삭제
               </Button>
               <DrawerClose>

--- a/src/shared/ui/SubPageHeader/SubPageHeader.tsx
+++ b/src/shared/ui/SubPageHeader/SubPageHeader.tsx
@@ -72,6 +72,19 @@ const SubPageHeader: React.FC<SubPageHeaderProps> = ({
           <X size={24} />
         </div>
       )}
+      {onClose && (
+        <div
+          aria-label='close button'
+          role='button'
+          className={cn(
+            buttonVariants({ variant: 'ghost' }),
+            'absolute right-5 size-6'
+          )}
+          onClick={onClose}
+        >
+          <X size={24} />
+        </div>
+      )}
       {onDelete && (
         <Drawer>
           <DrawerTrigger asChild>

--- a/src/shared/ui/SubPageHeader/SubPageHeader.tsx
+++ b/src/shared/ui/SubPageHeader/SubPageHeader.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from '@tanstack/react-router';
 import { X } from 'lucide-react';
 
 import { Button, buttonVariants } from '@/components/ui/button';
@@ -17,7 +16,6 @@ import { cn } from '@/shared/ui/styles/utils';
 
 export interface SubPageHeaderProps {
   title: string;
-  close?: boolean;
   onClickBack?: () => void;
   onClose?: () => void;
   onDelete?: () => void;
@@ -25,22 +23,10 @@ export interface SubPageHeaderProps {
 
 const SubPageHeader: React.FC<SubPageHeaderProps> = ({
   title,
-  close,
   onClickBack,
   onClose,
   onDelete,
 }) => {
-  const router = useRouter();
-
-  const handleClickClose = () => {
-    if (!onClose) {
-      router.history.back();
-      return;
-    }
-
-    onClose();
-  };
-
   return (
     <header className='flex flex-row justify-center items-center h-14 px-5 py-4'>
       {onClickBack && (
@@ -57,21 +43,6 @@ const SubPageHeader: React.FC<SubPageHeaderProps> = ({
         </div>
       )}
       <h1 className='text-[17px] text-[#222] font-semibold'>{title}</h1>
-      {close && (
-        <div
-          aria-label='close button'
-          role='button'
-          className={cn(
-            buttonVariants({ variant: 'ghost' }),
-            'absolute right-5 size-6'
-          )}
-          onClick={() => {
-            handleClickClose();
-          }}
-        >
-          <X size={24} />
-        </div>
-      )}
       {onClose && (
         <div
           aria-label='close button'

--- a/src/shared/ui/SubPageHeader/SubPaggeHeader.test.tsx
+++ b/src/shared/ui/SubPageHeader/SubPaggeHeader.test.tsx
@@ -18,12 +18,11 @@ import SubPageHeader, { SubPageHeaderProps } from './SubPageHeader';
 describe('SubPageHeader', () => {
   const props: SubPageHeaderProps = {
     title: 'sub page title',
-    back: undefined,
     close: undefined,
   };
 
-  const renderSubPageHeader = ({ title, back, close }: SubPageHeaderProps) =>
-    render(<SubPageHeader title={title} back={back} close={close} />);
+  const renderSubPageHeader = ({ title, close }: SubPageHeaderProps) =>
+    render(<SubPageHeader title={title} close={close} />);
 
   it('renders the provided title correctly.', () => {
     const { getByText } = renderSubPageHeader({ ...props });
@@ -31,20 +30,6 @@ describe('SubPageHeader', () => {
 
     expect(title).toBeInTheDocument();
     expect(title.tagName.toLowerCase()).toBe('h1');
-  });
-
-  it('renders provided back button, when clicks, calls router.history.back().', () => {
-    const { getByLabelText } = renderSubPageHeader({
-      ...props,
-      back: true,
-    });
-
-    const backButton = getByLabelText('back button');
-    expect(backButton).toBeInTheDocument();
-    expect(backButton).toHaveAttribute('role', 'button');
-
-    fireEvent.click(backButton);
-    expect(mockBack).toBeCalledTimes(1);
   });
 
   it('renders provided close button.', () => {

--- a/src/shared/ui/SubPageHeader/SubPaggeHeader.test.tsx
+++ b/src/shared/ui/SubPageHeader/SubPaggeHeader.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 // mock react-router useRouter().history.back()

--- a/src/shared/ui/SubPageHeader/SubPaggeHeader.test.tsx
+++ b/src/shared/ui/SubPageHeader/SubPaggeHeader.test.tsx
@@ -18,11 +18,10 @@ import SubPageHeader, { SubPageHeaderProps } from './SubPageHeader';
 describe('SubPageHeader', () => {
   const props: SubPageHeaderProps = {
     title: 'sub page title',
-    close: undefined,
   };
 
-  const renderSubPageHeader = ({ title, close }: SubPageHeaderProps) =>
-    render(<SubPageHeader title={title} close={close} />);
+  const renderSubPageHeader = ({ title }: SubPageHeaderProps) =>
+    render(<SubPageHeader title={title} />);
 
   it('renders the provided title correctly.', () => {
     const { getByText } = renderSubPageHeader({ ...props });
@@ -30,16 +29,5 @@ describe('SubPageHeader', () => {
 
     expect(title).toBeInTheDocument();
     expect(title.tagName.toLowerCase()).toBe('h1');
-  });
-
-  it('renders provided close button.', () => {
-    const { getByLabelText } = renderSubPageHeader({
-      ...props,
-      close: true,
-    });
-
-    const closeButton = getByLabelText('close button');
-    expect(closeButton).toBeInTheDocument();
-    expect(closeButton).toHaveAttribute('role', 'button');
   });
 });


### PR DESCRIPTION
- 소요시간: 40분
- 서브페이지간 이동이 `router.history.back()`에서 직접 `navigate` 하도록 지정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 헤더 내비게이션 버튼이 업데이트되어, 뒤로가기 및 닫기 등의 명시적 액션이 제공됩니다.
  - 버튼 클릭 시 특정 경로로 이동하는 기능이 추가되어 사용자 흐름이 개선되었습니다.
  
- **리팩터**
  - 기존의 기본 뒤로가기 및 닫기 옵션이 제거되고, 보다 일관되고 예측 가능한 인터랙션으로 개선되었습니다.

이러한 변경 사항은 다양한 페이지에서 보다 명확한 내비게이션 경험을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->