### PR TITLE
Add CategoriesPopover, CategoryPopover

### DIFF
--- a/src/app/routes/expenses.$uid.index.tsx
+++ b/src/app/routes/expenses.$uid.index.tsx
@@ -4,7 +4,6 @@ import { toast } from 'sonner';
 import {
   useDeleteExpense,
   useExpenseByUid,
-  useNewExpenseByUid,
   useUpdateExpense,
 } from '@/features/expense/api/useExpenseQuery';
 import { Expense } from '@/features/expense/model/types/Expense';
@@ -23,7 +22,6 @@ export function RouteComponent() {
 
   const { uid }: { uid: string } = Route.useParams();
   const { data: expense, isLoading, isError } = useExpenseByUid(uid);
-  const { newExpense, updateNewExpense } = useNewExpenseByUid(uid);
 
   if (isLoading) {
     return (
@@ -47,8 +45,6 @@ export function RouteComponent() {
     void navigate({ to: '/expenses' });
     return;
   }
-
-  updateNewExpense(expense);
 
   const handleDelete = () => {
     deleteExpense.mutate(uid, {
@@ -86,7 +82,7 @@ export function RouteComponent() {
         }}
         onDelete={handleDelete}
       />
-      <ExpenseForm expense={newExpense} onSubmit={handleSubmit} />
+      <ExpenseForm expense={expense} onSubmit={handleSubmit} />
     </UserLayout>
   );
 }

--- a/src/app/routes/expenses.$uid.index.tsx
+++ b/src/app/routes/expenses.$uid.index.tsx
@@ -5,7 +5,9 @@ import {
   useDeleteExpense,
   useExpenseByUid,
   useNewExpenseByUid,
+  useUpdateExpense,
 } from '@/features/expense/api/useExpenseQuery';
+import { Expense } from '@/features/expense/model/types/Expense';
 import ExpenseForm from '@/features/expense/ui/ExpenseForm';
 import UserLayout from '@/shared/ui/layout/UserLayout';
 import SubPageHeader from '@/shared/ui/SubPageHeader';
@@ -17,6 +19,7 @@ export const Route = createFileRoute('/expenses/$uid/')({
 export function RouteComponent() {
   const navigate = useNavigate();
   const deleteExpense = useDeleteExpense();
+  const updateExpense = useUpdateExpense();
 
   const { uid }: { uid: string } = Route.useParams();
   const { data: expense, isLoading, isError } = useExpenseByUid(uid);
@@ -59,6 +62,21 @@ export function RouteComponent() {
     });
   };
 
+  const handleSubmit = (expense: Omit<Expense, 'uid'>) => {
+    updateExpense.mutate(
+      { ...expense, uid },
+      {
+        onSuccess: () => {
+          toast.success('지출내역을 수정했어요.');
+          void navigate({ to: '/expenses' });
+        },
+        onError: () => {
+          toast.error('지출내역을 수정하는데 실패했어요.');
+        },
+      }
+    );
+  };
+
   return (
     <UserLayout>
       <SubPageHeader
@@ -68,7 +86,7 @@ export function RouteComponent() {
         }}
         onDelete={handleDelete}
       />
-      <ExpenseForm expense={newExpense} />
+      <ExpenseForm expense={newExpense} onSubmit={handleSubmit} />
     </UserLayout>
   );
 }

--- a/src/app/routes/expenses.new.index.tsx
+++ b/src/app/routes/expenses.new.index.tsx
@@ -42,7 +42,7 @@ export function RouteComponent() {
           void navigate({ to: '/expenses' });
         }}
       />
-      <ExpenseForm expense={newExpense} />
+      <ExpenseForm expense={newExpense} onSubmit={handleSubmit} />
     </UserLayout>
   );
 }

--- a/src/app/routes/expenses.new.index.tsx
+++ b/src/app/routes/expenses.new.index.tsx
@@ -1,10 +1,7 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { toast } from 'sonner';
 
-import {
-  useAddExpense,
-  useNewExpenseByUid,
-} from '@/features/expense/api/useExpenseQuery';
+import { useAddExpense } from '@/features/expense/api/useExpenseQuery';
 import { Expense } from '@/features/expense/model/types/Expense';
 import ExpenseForm from '@/features/expense/ui/ExpenseForm';
 import UserLayout from '@/shared/ui/layout/UserLayout';
@@ -16,8 +13,14 @@ export const Route = createFileRoute('/expenses/new/')({
 
 export function RouteComponent() {
   const navigate = useNavigate();
-  const { newExpense } = useNewExpenseByUid('new');
   const addExpense = useAddExpense();
+
+  const initialExpense: Omit<Expense, 'uid'> = {
+    date: new Date(),
+    memo: '',
+    categories: [],
+    amount: 0,
+  };
 
   const handleSubmit = (expense: Omit<Expense, 'uid'>) => {
     addExpense.mutate(
@@ -42,7 +45,7 @@ export function RouteComponent() {
           void navigate({ to: '/expenses' });
         }}
       />
-      <ExpenseForm expense={newExpense} onSubmit={handleSubmit} />
+      <ExpenseForm expense={initialExpense} onSubmit={handleSubmit} />
     </UserLayout>
   );
 }

--- a/src/app/routes/expenses.new.index.tsx
+++ b/src/app/routes/expenses.new.index.tsx
@@ -1,6 +1,11 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { toast } from 'sonner';
 
-import { useNewExpenseByUid } from '@/features/expense/api/useExpenseQuery';
+import {
+  useAddExpense,
+  useNewExpenseByUid,
+} from '@/features/expense/api/useExpenseQuery';
+import { Expense } from '@/features/expense/model/types/Expense';
 import ExpenseForm from '@/features/expense/ui/ExpenseForm';
 import UserLayout from '@/shared/ui/layout/UserLayout';
 import SubPageHeader from '@/shared/ui/SubPageHeader';
@@ -12,6 +17,22 @@ export const Route = createFileRoute('/expenses/new/')({
 export function RouteComponent() {
   const navigate = useNavigate();
   const { newExpense } = useNewExpenseByUid('new');
+  const addExpense = useAddExpense();
+
+  const handleSubmit = (expense: Omit<Expense, 'uid'>) => {
+    addExpense.mutate(
+      { ...expense },
+      {
+        onSuccess: () => {
+          toast.success('지출내역을 추가했어요.');
+          void navigate({ to: '/expenses' });
+        },
+        onError: () => {
+          toast.error('지출내역을 추가하는데 실패했어요.');
+        },
+      }
+    );
+  };
 
   return (
     <UserLayout>

--- a/src/features/category/api/useCategoryQuery.ts
+++ b/src/features/category/api/useCategoryQuery.ts
@@ -37,7 +37,7 @@ const useUpdateCategory = () => {
   return useUpdateCategoryQuery({
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: expenseQueryKeys.expenses });
-      // void qc.invalidateQueries({ queryKey: ['newExpense'] });
+      void qc.invalidateQueries({ queryKey: queryKeys.categories });
     },
   });
 };
@@ -47,7 +47,7 @@ const useDeleteCategory = () => {
   return useDeleteCategoryQuery({
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: expenseQueryKeys.expenses });
-      // void qc.invalidateQueries({ queryKey: ['newExpense'] });
+      void qc.invalidateQueries({ queryKey: queryKeys.categories });
     },
   });
 };

--- a/src/features/category/ui/CategoriesPopover.tsx
+++ b/src/features/category/ui/CategoriesPopover.tsx
@@ -39,7 +39,6 @@ export default function CategoriesPopover({
   );
 
   React.useEffect(() => {
-    console.log(selectedCategories);
     setValues(
       selectedCategories.map((selectedCategory) => selectedCategory.name)
     );
@@ -90,7 +89,7 @@ export default function CategoriesPopover({
     handleValues([...values, clickedCategory.name]);
   };
 
-  const onChangeCategory = (newCategory: Category) => {
+  const onUpdateCategory = (newCategory: Category) => {
     const index = selectedCategories.findIndex(
       (selectedCategory) => selectedCategory.uid === newCategory.uid
     );
@@ -99,12 +98,8 @@ export default function CategoriesPopover({
       return;
     }
 
-    const newSelectedCategories = [...selectedCategories].splice(
-      index,
-      1,
-      newCategory
-    );
-
+    const newSelectedCategories = [...selectedCategories];
+    newSelectedCategories.splice(index, 1, newCategory);
     setSelectedCategories(newSelectedCategories);
   };
 
@@ -130,7 +125,7 @@ export default function CategoriesPopover({
       {open && category && (
         <CategoryPopover
           category={category}
-          onChangeCategory={onChangeCategory}
+          onUpdateCategory={onUpdateCategory}
           onDeleteCategory={onDeleteCategory}
           onClose={() => {
             setOpen(false);

--- a/src/features/category/ui/CategoriesPopover.tsx
+++ b/src/features/category/ui/CategoriesPopover.tsx
@@ -59,11 +59,13 @@ export default function CategoriesPopover({
         { name: notAddedValue },
         {
           onSuccess: () => {
-            const addedCategory: Category[] = categories.filter(
-              (c) => c.name !== notAddedValue
+            const addedCategory = categories.find(
+              (c) => c.name === notAddedValue
             );
 
-            setSelectedCategories([...selectedCategories, ...addedCategory]);
+            if (addedCategory) {
+              setSelectedCategories([...selectedCategories, addedCategory]);
+            }
           },
           onError: () => {
             toast.error(notAddedValue + ' 카테고리를 추가하는데 실패했어요.');

--- a/src/features/category/ui/CategoriesPopover.tsx
+++ b/src/features/category/ui/CategoriesPopover.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import {
+  useAddCategory,
+  useCategories,
+} from '@/features/category/api/useCategoryQuery';
+import { Category } from '@/features/category/model/types/Category';
+import CategoryTag from '@/features/category/ui/CategoryTag';
+import InputCategoryTags from '@/features/category/ui/InputCategoryTags';
+import Ellipsis from '@/shared/ui/icons/Ellipsis';
+import UserLayout from '@/shared/ui/layout/UserLayout';
+import SubPageHeader from '@/shared/ui/SubPageHeader';
+
+interface Props {
+  selected: Category[];
+  setSelected: (values: Category[]) => void;
+  onClose: () => void;
+}
+
+export default function CategoriesPopover({
+  selected,
+  setSelected,
+  onClose,
+}: Props) {
+  const addCategory = useAddCategory();
+  const { categories, isLoading, isError, error } = useCategories();
+
+  const [values, setValues] = React.useState<string[]>(
+    selected.map((s) => s.name)
+  );
+
+  React.useEffect(() => {
+    setValues(selected.map((s) => s.name));
+  }, [selected]);
+
+  if (isLoading) {
+    return <>Loading</>;
+  }
+
+  if (isError && error) {
+    throw error;
+  }
+
+  const handleValues = (newValues: string[]) => {
+    if (categories === undefined) {
+      toast.error('어떠한 문제상황');
+      return;
+    }
+
+    const notAddedValues = newValues.filter(
+      (value) => !categories.some((c) => c.name === value)
+    );
+
+    notAddedValues.forEach((notAddedValue) => {
+      addCategory.mutate(
+        { name: notAddedValue },
+        {
+          onSuccess: () => {
+            const addedCategory: Category[] = categories.filter(
+              (c) => c.name !== notAddedValue
+            );
+
+            setSelected([...selected, ...addedCategory]);
+          },
+          onError: () => {
+            toast.error(notAddedValue + ' 카테고리를 추가하는데 실패했어요.');
+          },
+        }
+      );
+    });
+
+    setValues(newValues);
+  };
+
+  const onClickCategory = (clickedCategory: Category) => {
+    if (values.length >= 3) {
+      toast.error('카테고리는 최대 3개까지 선택할 수 있어요.');
+      return;
+    }
+
+    if (values.find((value) => clickedCategory.name === value)) {
+      toast.error('추가하려는 카테고리는 이미 선택되었어요.');
+      return;
+    }
+
+    handleValues([...values, clickedCategory.name]);
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        zIndex: 1,
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+      }}
+    >
+      <UserLayout>
+        <SubPageHeader title='카테고리 설정' onClose={onClose} />
+        <div className='mt-6 px-5'>
+          <InputCategoryTags
+            value={values}
+            onChange={handleValues}
+            placeholder='카테고리명을 입력해주세요. (예: 카페)'
+            maxLength={20}
+          />
+        </div>
+
+        {/* origin: pb-6  */}
+        <div className='flex-1 flex flex-col px-5 pt-9 pb-16'>
+          <p className='text-[13px] font-semibold text-[#999]'>카테고리 선택</p>
+          {categories === undefined || categories.length === 0 ? (
+            <p className='text-[13px] text-[#999] mt-47.5 mx-auto'>
+              아직 추가한 카테고리가 없어요.
+            </p>
+          ) : (
+            <ul className='flex flex-col gap-4 list-none overflow-y-scroll scroll mt-4'>
+              {categories.map((category) => {
+                return (
+                  <li className='flex flex-row items-center' key={category.uid}>
+                    <CategoryTag
+                      tagName={category.name}
+                      size='medium'
+                      onClick={() => {
+                        onClickCategory(category);
+                      }}
+                    />
+                    <Button
+                      variant='ghost'
+                      className='size-6 p-0 ml-auto'
+                      onClick={() => {
+                        console.log('onclick-setting-');
+                      }}
+                    >
+                      <Ellipsis size={24} color='#555' />
+                    </Button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+          <Button
+            //origin: mt-auto
+            className='h-13 rounded-full text-[15px] mt-auto'
+            onClick={() => {
+              setSelected([]);
+              onClose();
+            }}
+            disabled={
+              !categories || categories.length === 0 || values.length === 0
+            }
+          >
+            완료
+          </Button>
+        </div>
+      </UserLayout>
+    </div>
+  );
+}

--- a/src/features/category/ui/CategoriesPopover.tsx
+++ b/src/features/category/ui/CategoriesPopover.tsx
@@ -16,31 +16,33 @@ import SubPageHeader from '@/shared/ui/SubPageHeader';
 import CategoryPopover from './CategoryPopover';
 
 interface Props {
-  selected: Category[];
-  setSelected: (values: Category[]) => void;
+  selectedCategories: Category[];
+  setSelectedCategories: (values: Category[]) => void;
   onClose: () => void;
 }
 
 export default function CategoriesPopover({
-  selected,
-  setSelected,
+  selectedCategories,
+  setSelectedCategories,
   onClose,
 }: Props) {
   const addCategory = useAddCategory();
   const { categories, isLoading, isError, error } = useCategories();
 
-  const [open, setOpen] = React.useState<boolean>(false);
   const [values, setValues] = React.useState<string[]>(
-    selected.map((s) => s.name)
+    selectedCategories.map((selectedCategory) => selectedCategory.name)
   );
 
+  const [open, setOpen] = React.useState<boolean>(false);
   const [category, setCategory] = React.useState<Category | undefined>(
     undefined
   );
 
   React.useEffect(() => {
-    setValues(selected.map((s) => s.name));
-  }, [selected]);
+    setValues(
+      selectedCategories.map((selectedCategory) => selectedCategory.name)
+    );
+  }, [selectedCategories]);
 
   if (isLoading) {
     return <>Loading</>;
@@ -69,7 +71,7 @@ export default function CategoriesPopover({
               (c) => c.name !== notAddedValue
             );
 
-            setSelected([...selected, ...addedCategory]);
+            setSelectedCategories([...selectedCategories, ...addedCategory]);
           },
           onError: () => {
             toast.error(notAddedValue + ' 카테고리를 추가하는데 실패했어요.');
@@ -164,7 +166,7 @@ export default function CategoriesPopover({
             //origin: mt-auto
             className='h-13 rounded-full text-[15px] mt-auto'
             onClick={() => {
-              setSelected(
+              setSelectedCategories(
                 categories
                   ? categories.filter((c) =>
                       values.find((value) => value === c.name)

--- a/src/features/category/ui/CategoriesPopover.tsx
+++ b/src/features/category/ui/CategoriesPopover.tsx
@@ -39,6 +39,7 @@ export default function CategoriesPopover({
   );
 
   React.useEffect(() => {
+    console.log(selectedCategories);
     setValues(
       selectedCategories.map((selectedCategory) => selectedCategory.name)
     );
@@ -89,6 +90,32 @@ export default function CategoriesPopover({
     handleValues([...values, clickedCategory.name]);
   };
 
+  const onChangeCategory = (newCategory: Category) => {
+    const index = selectedCategories.findIndex(
+      (selectedCategory) => selectedCategory.uid === newCategory.uid
+    );
+
+    if (index === -1) {
+      return;
+    }
+
+    const newSelectedCategories = [...selectedCategories].splice(
+      index,
+      1,
+      newCategory
+    );
+
+    setSelectedCategories(newSelectedCategories);
+  };
+
+  const onDeleteCategory = (uid: string) => {
+    const newCategories = selectedCategories.filter(
+      (selectedCategory) => selectedCategory.uid !== uid
+    );
+
+    setSelectedCategories(newCategories);
+  };
+
   return (
     <div
       style={{
@@ -103,6 +130,8 @@ export default function CategoriesPopover({
       {open && category && (
         <CategoryPopover
           category={category}
+          onChangeCategory={onChangeCategory}
+          onDeleteCategory={onDeleteCategory}
           onClose={() => {
             setOpen(false);
           }}

--- a/src/features/category/ui/CategoriesPopover.tsx
+++ b/src/features/category/ui/CategoriesPopover.tsx
@@ -46,7 +46,6 @@ export default function CategoriesPopover({
 
   const handleValues = (newValues: string[]) => {
     if (categories === undefined) {
-      toast.error('어떠한 문제상황');
       return;
     }
 

--- a/src/features/category/ui/CategoriesPopover.tsx
+++ b/src/features/category/ui/CategoriesPopover.tsx
@@ -13,6 +13,8 @@ import Ellipsis from '@/shared/ui/icons/Ellipsis';
 import UserLayout from '@/shared/ui/layout/UserLayout';
 import SubPageHeader from '@/shared/ui/SubPageHeader';
 
+import CategoryPopover from './CategoryPopover';
+
 interface Props {
   selected: Category[];
   setSelected: (values: Category[]) => void;
@@ -27,8 +29,13 @@ export default function CategoriesPopover({
   const addCategory = useAddCategory();
   const { categories, isLoading, isError, error } = useCategories();
 
+  const [open, setOpen] = React.useState<boolean>(false);
   const [values, setValues] = React.useState<string[]>(
     selected.map((s) => s.name)
+  );
+
+  const [category, setCategory] = React.useState<Category | undefined>(
+    undefined
   );
 
   React.useEffect(() => {
@@ -99,6 +106,14 @@ export default function CategoriesPopover({
         height: '100%',
       }}
     >
+      {open && category && (
+        <CategoryPopover
+          category={category}
+          onClose={() => {
+            setOpen(false);
+          }}
+        />
+      )}
       <UserLayout>
         <SubPageHeader title='카테고리 설정' onClose={onClose} />
         <div className='mt-6 px-5'>
@@ -130,10 +145,12 @@ export default function CategoriesPopover({
                       }}
                     />
                     <Button
+                      type='button'
                       variant='ghost'
                       className='size-6 p-0 ml-auto'
                       onClick={() => {
-                        console.log('onclick-setting-');
+                        setCategory(category);
+                        setOpen(true);
                       }}
                     >
                       <Ellipsis size={24} color='#555' />

--- a/src/features/category/ui/CategoriesPopover.tsx
+++ b/src/features/category/ui/CategoriesPopover.tsx
@@ -147,7 +147,13 @@ export default function CategoriesPopover({
             //origin: mt-auto
             className='h-13 rounded-full text-[15px] mt-auto'
             onClick={() => {
-              setSelected([]);
+              setSelected(
+                categories
+                  ? categories.filter((c) =>
+                      values.find((value) => value === c.name)
+                    )
+                  : []
+              );
               onClose();
             }}
             disabled={

--- a/src/features/category/ui/CategoriesPopover.tsx
+++ b/src/features/category/ui/CategoriesPopover.tsx
@@ -27,7 +27,7 @@ export default function CategoriesPopover({
   onClose,
 }: Props) {
   const addCategory = useAddCategory();
-  const { categories, isLoading, isError, error } = useCategories();
+  const { categories } = useCategories();
 
   const [values, setValues] = React.useState<string[]>(
     selectedCategories.map((selectedCategory) => selectedCategory.name)
@@ -43,14 +43,6 @@ export default function CategoriesPopover({
       selectedCategories.map((selectedCategory) => selectedCategory.name)
     );
   }, [selectedCategories]);
-
-  if (isLoading) {
-    return <>Loading</>;
-  }
-
-  if (isError && error) {
-    throw error;
-  }
 
   const handleValues = (newValues: string[]) => {
     if (categories === undefined) {

--- a/src/features/category/ui/CategoryPopover.tsx
+++ b/src/features/category/ui/CategoryPopover.tsx
@@ -27,10 +27,17 @@ import UnderlinedTextInput from '@/shared/ui/UnderlinedTextInput';
 
 interface Props {
   category: Category;
+  onChangeCategory: (category: Category) => void;
+  onDeleteCategory: (uid: string) => void;
   onClose: () => void;
 }
 
-export default function CategoryPopover({ category, onClose }: Props) {
+export default function CategoryPopover({
+  category,
+  onChangeCategory,
+  onDeleteCategory,
+  onClose,
+}: Props) {
   const updateCategory = useUpdateCategory();
   const deleteCategory = useDeleteCategory();
   const { categories } = useCategories();
@@ -54,6 +61,7 @@ export default function CategoryPopover({ category, onClose }: Props) {
   };
 
   const onSubmit = (values: { categoryName: string }) => {
+    console.log('onsubmit');
     if (values.categoryName.length === 0) {
       toast.error('카테고리는 최소 한 글자 이상 입력해야 합니다.');
       return;
@@ -68,21 +76,25 @@ export default function CategoryPopover({ category, onClose }: Props) {
       return;
     }
 
-    updateCategory.mutate(
-      { uid: category.uid, name: values.categoryName },
-      {
-        onSuccess: () => {
-          toast.success('카테고리 이름을 업데이트했어요.');
-          onClose();
-        },
-      }
-    );
+    const updatedCategory: Category = {
+      uid: category.uid,
+      name: values.categoryName,
+    };
+
+    updateCategory.mutate(updatedCategory, {
+      onSuccess: () => {
+        toast.success('카테고리 이름을 업데이트했어요.');
+        onChangeCategory(updatedCategory);
+        onClose();
+      },
+    });
   };
 
   const onDelete = () => {
     deleteCategory.mutate(category.uid, {
       onSuccess: () => {
         toast.success(category.name + '카테고리를 삭제했어요.');
+        onDeleteCategory(category.uid);
         onClose();
       },
     });
@@ -130,6 +142,7 @@ export default function CategoryPopover({ category, onClose }: Props) {
             <div className='flex flex-row w-full gap-2 mt-auto'>
               <Drawer>
                 <DrawerTrigger
+                  type='button'
                   className={cn(
                     buttonVariants({ variant: 'default' }),
                     'flex-1 rounded-full h-13 text-[15px] text-[#222] bg-[#efefef] hover:bg-[#efefef]/80'

--- a/src/features/category/ui/CategoryPopover.tsx
+++ b/src/features/category/ui/CategoryPopover.tsx
@@ -27,14 +27,14 @@ import UnderlinedTextInput from '@/shared/ui/UnderlinedTextInput';
 
 interface Props {
   category: Category;
-  onChangeCategory: (category: Category) => void;
+  onUpdateCategory: (category: Category) => void;
   onDeleteCategory: (uid: string) => void;
   onClose: () => void;
 }
 
 export default function CategoryPopover({
   category,
-  onChangeCategory,
+  onUpdateCategory,
   onDeleteCategory,
   onClose,
 }: Props) {
@@ -61,7 +61,6 @@ export default function CategoryPopover({
   };
 
   const onSubmit = (values: { categoryName: string }) => {
-    console.log('onsubmit');
     if (values.categoryName.length === 0) {
       toast.error('카테고리는 최소 한 글자 이상 입력해야 합니다.');
       return;
@@ -84,7 +83,7 @@ export default function CategoryPopover({
     updateCategory.mutate(updatedCategory, {
       onSuccess: () => {
         toast.success('카테고리 이름을 업데이트했어요.');
-        onChangeCategory(updatedCategory);
+        onUpdateCategory(updatedCategory);
         onClose();
       },
     });

--- a/src/features/category/ui/CategoryPopover.tsx
+++ b/src/features/category/ui/CategoryPopover.tsx
@@ -68,7 +68,7 @@ export default function CategoryPopover({
 
     if (
       categories?.find(
-        (c) => c.name === values.categoryName && c.uid !== category.name
+        (c) => c.name === values.categoryName && c.uid !== category.uid
       )
     ) {
       toast.error('동일한 카테고리 이름이 존재합니다.');

--- a/src/features/category/ui/CategoryPopover.tsx
+++ b/src/features/category/ui/CategoryPopover.tsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+
+import { Button, buttonVariants } from '@/components/ui/button';
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/components/ui/drawer';
+import { Form, FormControl, FormField, FormItem } from '@/components/ui/form';
+import {
+  useCategories,
+  useDeleteCategory,
+  useUpdateCategory,
+} from '@/features/category/api/useCategoryQuery';
+import { Category } from '@/features/category/model/types/Category';
+import UserLayout from '@/shared/ui/layout/UserLayout';
+import { cn } from '@/shared/ui/styles/utils';
+import SubPageHeader from '@/shared/ui/SubPageHeader';
+import UnderlinedTextInput from '@/shared/ui/UnderlinedTextInput';
+
+interface Props {
+  category: Category;
+  onClose: () => void;
+}
+
+export default function CategoryPopover({ category, onClose }: Props) {
+  const updateCategory = useUpdateCategory();
+  const deleteCategory = useDeleteCategory();
+  const { categories } = useCategories();
+
+  const [disabled, setDisabled] = React.useState<boolean>(true);
+
+  const form = useForm<{ categoryName: string }>({
+    defaultValues: { categoryName: category.name },
+  });
+
+  const validateInput = (newValue: string) => {
+    if (
+      newValue === category.name ||
+      newValue.length === 0 ||
+      newValue.length > 20
+    ) {
+      setDisabled(true);
+    } else {
+      setDisabled(false);
+    }
+  };
+
+  const onSubmit = (values: { categoryName: string }) => {
+    if (values.categoryName.length === 0) {
+      toast.error('카테고리는 최소 한 글자 이상 입력해야 합니다.');
+      return;
+    }
+
+    if (
+      categories?.find(
+        (c) => c.name === values.categoryName && c.uid !== category.name
+      )
+    ) {
+      toast.error('동일한 카테고리 이름이 존재합니다.');
+      return;
+    }
+
+    updateCategory.mutate(
+      { uid: category.uid, name: values.categoryName },
+      {
+        onSuccess: () => {
+          toast.success('카테고리 이름을 업데이트했어요.');
+          onClose();
+        },
+      }
+    );
+  };
+
+  const onDelete = () => {
+    deleteCategory.mutate(category.uid, {
+      onSuccess: () => {
+        toast.success(category.name + '카테고리를 삭제했어요.');
+        onClose();
+      },
+    });
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        zIndex: 1,
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+      }}
+    >
+      <UserLayout>
+        <SubPageHeader title='카테고리명 편집' onClose={onClose} />
+        <Form {...form}>
+          <form
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
+            onSubmit={form.handleSubmit(onSubmit)}
+            className='flex-1 flex flex-col h-fit py-6 px-5 mb-auto'
+          >
+            <FormField
+              control={form.control}
+              name='categoryName'
+              render={({ field }) => (
+                <FormItem>
+                  <FormControl>
+                    <UnderlinedTextInput
+                      value={field.value}
+                      onChange={(newValue) => {
+                        validateInput(newValue);
+                        field.onChange(newValue);
+                      }}
+                      placeholder='카테고리명을 입력하세요.'
+                      guideText='최대 20자 입력'
+                      maxLength={20}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+            <div className='flex flex-row w-full gap-2 mt-auto'>
+              <Drawer>
+                <DrawerTrigger
+                  className={cn(
+                    buttonVariants({ variant: 'default' }),
+                    'flex-1 rounded-full h-13 text-[15px] text-[#222] bg-[#efefef] hover:bg-[#efefef]/80'
+                  )}
+                >
+                  삭제
+                </DrawerTrigger>
+                <DrawerContent className='w-full max-w-sm mx-auto py-8 px-5 rounded-t-[20px]'>
+                  <DrawerHeader className='p-0'>
+                    <DrawerTitle className='text-[19px] text-[#222] font-semibold'>
+                      카테고리를 삭제할까요?
+                    </DrawerTitle>
+                    <DrawerDescription className='text-15px text-[#555]'>
+                      카테고리를 삭제하면, 연결된 지출 내역의 {category.name}{' '}
+                      태그도 함께 삭제돼요.
+                    </DrawerDescription>
+                  </DrawerHeader>
+                  <DrawerFooter className='p-0 mt-9'>
+                    <Button className='h-13 rounded-full' onClick={onDelete}>
+                      삭제
+                    </Button>
+                    <DrawerClose>
+                      <Button
+                        variant='ghost'
+                        className='h-13 w-full rounded-full'
+                      >
+                        취소
+                      </Button>
+                    </DrawerClose>
+                  </DrawerFooter>
+                </DrawerContent>
+              </Drawer>
+              <Button
+                type='submit'
+                className='flex-1 rounded-full h-13 text-[15px] text-white bg-[#222] hover:bg-[#222]/80'
+                disabled={disabled}
+              >
+                저장
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </UserLayout>
+    </div>
+  );
+}

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.test.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
-import { describe, it } from 'vitest';
+import { describe, it, vi } from 'vitest';
 
 import { Expense } from '@/features/expense/model/types/Expense';
 
@@ -17,12 +17,12 @@ describe('ExpenseForm', () => {
     categories: [],
   };
 
-  const props: ExpenseFormProps = { expense };
+  const props: ExpenseFormProps = { expense, onSubmit: vi.fn() };
 
-  const renderElement = ({ expense }: ExpenseFormProps) =>
+  const renderElement = ({ expense, onSubmit }: ExpenseFormProps) =>
     render(
       <QueryClientProvider client={testQueryClient}>
-        <ExpenseForm expense={expense} />
+        <ExpenseForm expense={expense} onSubmit={onSubmit} />
       </QueryClientProvider>
     );
 
@@ -74,7 +74,7 @@ describe('ExpenseForm', () => {
 
     it('renders 저장 when expense is provided.', () => {
       const { getByRole } = renderElement({
-        expense: { ...expense },
+        ...props,
       });
       const submitButton = getByRole('button', { name: '저장' });
       expect(submitButton).toBeInTheDocument();

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -1,8 +1,7 @@
-import { Link, useNavigate } from '@tanstack/react-router';
+import { Link } from '@tanstack/react-router';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import { NumberFormatValues, NumericFormat } from 'react-number-format';
-import { toast } from 'sonner';
 
 import { Button, buttonVariants } from '@/components/ui/button';
 import {
@@ -13,11 +12,6 @@ import {
   FormLabel,
 } from '@/components/ui/form';
 import CategoryTag from '@/features/category/ui/CategoryTag';
-import {
-  useAddExpense,
-  useNewExpenseByUid,
-  useUpdateExpense,
-} from '@/features/expense/api/useExpenseQuery';
 import {
   EXPENSE_AMOUNT_MAX,
   EXPENSE_MEMO_MAX_LEN,
@@ -51,7 +45,6 @@ export interface ExpenseFormProps {
 }
 
 const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
-  const navigate = useNavigate();
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   const form = useForm<Omit<Expense, 'uid'>>({
@@ -66,14 +59,9 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
 
   const { handleSubmit, watch } = form;
 
-  const date = watch('date');
   const memo = watch('memo');
   const categories = watch('categories');
   const amount = watch('amount');
-
-  const handleClickCategory = () => {
-    updateNewExpense({ uid: expense.uid, date, memo, categories, amount });
-  };
 
   const disabled = React.useMemo(() => {
     if (memo.length === 0 || memo.length > 120) {

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -47,14 +47,11 @@ const CalendarDrawerTrigger = ({ date }: { date: Date }) => {
 
 export interface ExpenseFormProps {
   expense: Expense;
+  onSubmit: (expense: Omit<Expense, 'uid'>) => void;
 }
 
-const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense }) => {
+const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
   const navigate = useNavigate();
-  const updateExpense = useUpdateExpense();
-  const addExpense = useAddExpense();
-  const { updateNewExpense } = useNewExpenseByUid(expense.uid);
-
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   const form = useForm<Omit<Expense, 'uid'>>({
@@ -94,59 +91,12 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense }) => {
     return false;
   }, [memo, categories, amount]);
 
-  const handleOnSubmit = (values: Omit<Expense, 'uid'>) => {
-    if (expense.uid === 'new') {
-      addExpense.mutate(
-        { ...values },
-        {
-          onSuccess: () => {
-            toast.success('지출내역을 추가했어요.');
-            updateNewExpense({
-              uid: expense.uid,
-              date: new Date(),
-              memo: '',
-              amount: 0,
-              categories: [],
-            });
-
-            void navigate({ to: '/expenses' });
-          },
-          onError: () => {
-            toast.error('지출내역을 추가하는데 실패했어요.');
-          },
-        }
-      );
-      return;
-    } else {
-      updateExpense.mutate(
-        { uid: expense.uid, ...values },
-        {
-          onSuccess: () => {
-            toast.success('지출내역을 수정했어요.');
-            updateNewExpense({
-              uid: expense.uid,
-              date: new Date(),
-              memo: '',
-              amount: 0,
-              categories: [],
-            });
-
-            void navigate({ to: '/expenses' });
-          },
-          onError: () => {
-            toast.error('지출내역을 수정하는데 실패했어요.');
-          },
-        }
-      );
-    }
-  };
-
   return (
     <Form {...form}>
       <form
         className='flex flex-col gap-6 h-screen pt-6 px-5 pb-20'
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        onSubmit={handleSubmit(handleOnSubmit)}
+        onSubmit={handleSubmit(onSubmit)}
       >
         <FormField
           control={form.control}

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -40,7 +40,7 @@ const CalendarDrawerTrigger = ({ date }: { date: Date }) => {
 };
 
 export interface ExpenseFormProps {
-  expense: Expense;
+  expense: Omit<Expense, 'uid'>;
   onSubmit: (expense: Omit<Expense, 'uid'>) => void;
 }
 

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -10,6 +10,7 @@ import {
   FormItem,
   FormLabel,
 } from '@/components/ui/form';
+import CategoriesPopover from '@/features/category/ui/CategoriesPopover';
 import CategoryTag from '@/features/category/ui/CategoryTag';
 import {
   EXPENSE_AMOUNT_MAX,
@@ -79,6 +80,17 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
 
   return (
     <Form {...form}>
+      {open && (
+        <CategoriesPopover
+          selected={categories}
+          setSelected={(values) => {
+            form.setValue('categories', values);
+          }}
+          onClose={() => {
+            setOpen(false);
+          }}
+        />
+      )}
       <form
         className='flex flex-col gap-6 h-screen pt-6 px-5 pb-20'
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -155,7 +167,9 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
                   id='categories'
                   aria-label='카테고리 설정 버튼'
                   className='rounded-full bg-[#efefef] hover:bg-accent h-auto text-[13px] text-[#555] ml-auto py-1 px-2'
-                  onClick={onClickCategoryButton}
+                  onClick={() => {
+                    setOpen(true);
+                  }}
                 >
                   설정
                 </Button>

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -1,4 +1,3 @@
-import { Link } from '@tanstack/react-router';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import { NumberFormatValues, NumericFormat } from 'react-number-format';
@@ -46,6 +45,7 @@ export interface ExpenseFormProps {
 
 const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const [open, setOpen] = React.useState<boolean>(false);
 
   const form = useForm<Omit<Expense, 'uid'>>({
     defaultValues: {
@@ -157,6 +157,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
                   id='categories'
                   aria-label='카테고리 설정 버튼'
                   className='rounded-full bg-[#efefef] hover:bg-accent h-auto text-[13px] text-[#555] ml-auto py-1 px-2'
+                  onClick={onClickCategoryButton}
                 >
                   설정
                 </Button>

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -164,7 +164,6 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
                         ? '/expenses/new/categories'
                         : '/expenses/$uid/categories'
                     }
-                    onClick={handleClickCategory}
                     params={{ uid: expense.uid }}
                   >
                     설정

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -153,21 +153,12 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
                   카테고리
                 </FormLabel>
                 <Button
+                  type='button'
                   id='categories'
                   aria-label='카테고리 설정 버튼'
                   className='rounded-full bg-[#efefef] hover:bg-accent h-auto text-[13px] text-[#555] ml-auto py-1 px-2'
-                  asChild
                 >
-                  <Link
-                    to={
-                      expense.uid === 'new'
-                        ? '/expenses/new/categories'
-                        : '/expenses/$uid/categories'
-                    }
-                    params={{ uid: expense.uid }}
-                  >
-                    설정
-                  </Link>
+                  설정
                 </Button>
               </div>
               <div className='flex flex-row gap-2 flex-wrap'>

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -44,9 +44,7 @@ export interface ExpenseFormProps {
 }
 
 const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
-  const inputRef = React.useRef<HTMLInputElement>(null);
   const [open, setOpen] = React.useState<boolean>(false);
-
   const form = useForm<Omit<Expense, 'uid'>>({
     defaultValues: {
       date: expense.date,
@@ -180,7 +178,6 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
                 <NumericFormat
                   inputMode='numeric'
                   value={field.value}
-                  getInputRef={inputRef}
                   max={EXPENSE_AMOUNT_MAX}
                   min={1}
                   isAllowed={(values: NumberFormatValues) => {

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -82,8 +82,8 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
     <Form {...form}>
       {open && (
         <CategoriesPopover
-          selected={categories}
-          setSelected={(values) => {
+          selectedCategories={categories}
+          setSelectedCategories={(values) => {
             form.setValue('categories', values);
           }}
           onClose={() => {


### PR DESCRIPTION
- 작업시간: 3시간
- categories, category 페이지들을 팝오버로 구현
- 현재 CategoryPopover에서 카테고리명 수정시 카테고리 선택, 지출내역 수정/추가에서 반영 안됨
  - props로 CategoryPopover에서 수정시 지출내역까지 수정하는 기능 구현예정(12일 아침)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 기존 경비 업데이트 및 신규 경비 추가 기능 개선
  - 사용자에게 성공 및 오류 알림을 통한 피드백 제공
  - 카테고리 선택, 추가, 편집, 삭제를 지원하는 새로운 인터페이스 도입

- **리팩터**
  - 경비 제출 로직이 내부 상태 관리에서 prop 기반 방식으로 간소화

- **테스트**
  - 경비 폼 제출 동작 검증을 위한 테스트 업데이트 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->