### PR TITLE
카테고리 목록 페이지의 하단 버튼이 데스크톱에서 화면 너비와 맞는 현상 수정

### DIFF
--- a/src/features/category/ui/CategoriesPopover.tsx
+++ b/src/features/category/ui/CategoriesPopover.tsx
@@ -113,9 +113,7 @@ export default function CategoriesPopover({
   };
 
   return (
-    <div
-      className='fixed z-10 top-0 left-0 w-full h-full flex flex-col overflow-hidden'
-    >
+    <div className='fixed z-10 top-0 left-0 w-full h-full flex flex-col overflow-hidden'>
       {open && category && (
         <CategoryPopover
           category={category}
@@ -138,7 +136,9 @@ export default function CategoriesPopover({
         </div>
 
         <div className='flex flex-col px-5 flex-1 overflow-hidden'>
-          <p className='text-[13px] font-semibold text-[#999] my-4'>카테고리 선택</p>
+          <p className='text-[13px] font-semibold text-[#999] my-4'>
+            카테고리 선택
+          </p>
           <div className='flex-1 overflow-hidden'>
             {categories === undefined || categories.length === 0 ? (
               <p className='text-[13px] text-[#999] mt-47.5 mx-auto'>
@@ -149,7 +149,10 @@ export default function CategoriesPopover({
                 <ul className='flex flex-col gap-4 list-none'>
                   {categories.map((category) => {
                     return (
-                      <li className='flex flex-row items-center' key={category.uid}>
+                      <li
+                        className='flex flex-row items-center'
+                        key={category.uid}
+                      >
                         <CategoryTag
                           tagName={category.name}
                           size='medium'
@@ -176,7 +179,7 @@ export default function CategoriesPopover({
             )}
           </div>
         </div>
-        <div className='fixed bottom-0 left-0 right-0 px-5 py-4 bg-white border-t border-gray-100'>
+        <div className='fixed bottom-0 left-0 right-0 w-full min-w-[375px] max-w-[430px] mx-auto px-5 py-4 bg-white border-t border-gray-100'>
           <Button
             className='h-13 rounded-full text-[15px] w-full'
             onClick={() => {


### PR DESCRIPTION
- 카테고리 목록 페이지의 하단 버튼이 데스크톱에서 화면 너비와 맞는 현상 수정
- 소요시간: 10분

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - UI 구성 요소의 태그 정렬과 구조를 개선하여 코드 가독성을 향상했습니다.
  - 버튼 영역에 폭 제약을 추가해 레이아웃 제어를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->