### PR TITLE
agreements 라우트 헤더에서 뒤로가기 버튼 삭제, 스크롤 안되는 현상 해결

### DIFF
--- a/src/app/routes.custom.tsx
+++ b/src/app/routes.custom.tsx
@@ -25,12 +25,7 @@ const termsRoute = createRoute({
   path: 'terms.html',
   component: () => (
     <>
-      <SubPageHeader
-        title='이용약관'
-        onClickBack={() => {
-          void redirect({ to: '/settings' });
-        }}
-      />
+      <SubPageHeader title='이용약관' />
       <TermsPage />
     </>
   ),
@@ -41,12 +36,7 @@ const privacyRoute = createRoute({
   path: 'privacy.html',
   component: () => (
     <>
-      <SubPageHeader
-        title='개인정보 처리방침'
-        onClickBack={() => {
-          void redirect({ to: '/settings' });
-        }}
-      />
+      <SubPageHeader title='개인정보 처리방침' />
       <PrivacyPage />
     </>
   ),

--- a/src/shared/ui/layout/Layout.tsx
+++ b/src/shared/ui/layout/Layout.tsx
@@ -1,6 +1,6 @@
 const Layout: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   return (
-    <div className='w-full min-w-[375px] max-w-[430px] mx-auto h-dvh bg-white relative flex flex-col overflow-hidden'>
+    <div className='w-full min-w-[375px] max-w-[430px] mx-auto h-dvh bg-white relative flex flex-col overflow-auto scroll'>
       {children}
     </div>
   );


### PR DESCRIPTION
- 소요시간: 5분
- Layout에 overflow-auto, 커스텀 스크롤 적용