### PR TITLE
지출내역 수정/추가시 스크롤 이벤트 수정

### DIFF
--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -92,7 +92,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
         />
       )}
       <form
-        className='flex flex-col gap-8 h-screen pt-6 px-5 pb-20'
+        className='flex flex-col gap-8 h-screen pt-6 px-5'
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         onSubmit={handleSubmit(onSubmit)}
       >
@@ -222,14 +222,16 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
             </FormItem>
           )}
         />
-        <Button
-          type='submit'
-          // origin: mt-auto
-          className='h-13 text-[15px] font-semibold mt-auto rounded-full'
-          disabled={disabled}
-        >
-          저장
-        </Button>
+        <div className='fixed bottom-0 left-0 right-0 w-full min-w-[375px] max-w-[430px] mx-auto px-5 py-4 bg-white border-t border-gray-100'>
+          <Button
+            type='submit'
+            // origin: mt-auto
+            className='w-full h-13 text-[15px] font-semibold mt-auto rounded-full'
+            disabled={disabled}
+          >
+            저장
+          </Button>
+        </div>
       </form>
     </Form>
   );


### PR DESCRIPTION
- 작업시간: 5분
- 하단 버튼을 CategoriesPopover처럼 div wrapper로 감싸 해결
![image](https://github.com/user-attachments/assets/563c6c2c-84f4-4ca7-b8cd-b2629bfe14b9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 제출 버튼이 화면 하단에 고정되어 항상 보입니다.
  - 버튼이 전체 너비로 조정되어 시각적 일관성이 향상됩니다.
  - 폼 하단의 불필요한 여백이 제거되어 깔끔한 레이아웃을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->