### PR TITLE
카테고리 리스트 스크롤이 화면 가장 우측으로 가도록 수정

### DIFF
--- a/src/features/category/ui/CategoriesPopover.tsx
+++ b/src/features/category/ui/CategoriesPopover.tsx
@@ -135,8 +135,8 @@ export default function CategoriesPopover({
           />
         </div>
 
-        <div className='flex flex-col px-5 flex-1 overflow-hidden'>
-          <p className='text-[13px] font-semibold text-[#999] my-4'>
+        <div className='flex flex-col flex-1 overflow-hidden'>
+          <p className='text-[13px] font-semibold text-[#999] my-4 px-5'>
             카테고리 선택
           </p>
           <div className='flex-1 overflow-hidden'>
@@ -145,7 +145,7 @@ export default function CategoriesPopover({
                 아직 추가한 카테고리가 없어요.
               </p>
             ) : (
-              <div className='h-full overflow-y-auto pr-1 pb-24 scroll'>
+              <div className='h-full overflow-y-auto mx-auto px-5 pr-1 pb-24 scroll'>
                 <ul className='flex flex-col gap-4 list-none'>
                   {categories.map((category) => {
                     return (
@@ -163,7 +163,7 @@ export default function CategoriesPopover({
                         <Button
                           type='button'
                           variant='ghost'
-                          className='size-6 p-0 ml-auto'
+                          className='size-6 p-0 ml-auto mr-[16px]'
                           onClick={() => {
                             setCategory(category);
                             setOpen(true);


### PR DESCRIPTION
- 소요시간: 20분

수정 전
<img width="391" alt="image" src="https://github.com/user-attachments/assets/aa6474c1-12c5-4563-9875-297945c6329e" />

수정 후
<img width="391" alt="image" src="https://github.com/user-attachments/assets/149a33a9-4418-40ab-bae5-8b8f7a065bf4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
	- 카테고리 선택 영역의 간격과 정렬을 조정하여 인터페이스가 더욱 깔끔하게 개선되었습니다.
	- 텍스트 및 버튼의 위치와 여백이 조율되어 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->