### PR TITLE
로그인 페이지 loader에서 401 에러 핸들링 수정

### DIFF
--- a/src/app/routes/login.index.tsx
+++ b/src/app/routes/login.index.tsx
@@ -18,7 +18,7 @@ export const Route = createFileRoute('/login/')({
       }
     } catch (error) {
       if (error instanceof AxiosError) {
-        if (error.status === 401) {
+        if (error.response?.status === 401) {
           localStorage.removeItem(TOKEN_KEY);
         }
       }

--- a/src/app/routes/login.index.tsx
+++ b/src/app/routes/login.index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, redirect } from '@tanstack/react-router';
+import { AxiosError } from 'axios';
 
 import { TOKEN_KEY } from '@/constants';
 import SignInButton from '@/features/auth/ui/SignInButton';
@@ -15,11 +16,12 @@ export const Route = createFileRoute('/login/')({
       if (res.status === 200) {
         return redirect({ to: '/expenses' });
       }
-      if (res.status === 401) {
-        localStorage.removeItem(TOKEN_KEY);
-        return;
+    } catch (error) {
+      if (error instanceof AxiosError) {
+        if (error.status === 401) {
+          localStorage.removeItem(TOKEN_KEY);
+        }
       }
-    } catch {
       return;
     }
   },


### PR DESCRIPTION
- 소요시간: 10분
- 로그인 페이지 route의 loader 수정
- Axios get 401 에러는 try 문에서 핸들링하는 것이 아니고, catch 문에서 error instanceof AxiosError 값으로 잡아야한다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
	- 로그인 시 발생할 수 있는 인증 오류를 보다 안정적으로 처리하도록 개선하여, 오류 발생 시 인증 정보가 적절하게 초기화되도록 했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->