### PR TITLE
(coderabbitai review용 PR)MemoClamp 기능 추가, ReviewExpenseCard 추가

### DIFF
--- a/src/app/routes/expenses.review.index.tsx
+++ b/src/app/routes/expenses.review.index.tsx
@@ -32,7 +32,7 @@ function RouteComponent() {
     {
       uid: 'expense-2',
       date: new Date(),
-      memo: '엄청나게 긴 메모',
+      memo: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard",
       amount: 10000,
       categories: [
         {

--- a/src/features/expense/ui/ReviewExpenseCard.tsx
+++ b/src/features/expense/ui/ReviewExpenseCard.tsx
@@ -14,9 +14,20 @@ const ReviewExpenseCard: React.FC<{ expense: Expense }> = ({ expense }) => {
 
   useLayoutEffect(() => {
     const element = memoRef.current;
-    if (element) {
-      setIsMemoOverflowing(element.scrollHeight > element.clientHeight);
+    if (!element) {
+      return;
     }
+
+    const originalClass = element.className;
+
+    element.classList.add('line-clamp-1');
+
+    requestAnimationFrame(() => {
+      const isOverflowing = element.scrollHeight > element.clientHeight;
+      setIsMemoOverflowing(isOverflowing);
+
+      element.className = originalClass;
+    });
   }, [memoRef]);
 
   return (
@@ -39,20 +50,24 @@ const ReviewExpenseCard: React.FC<{ expense: Expense }> = ({ expense }) => {
           {expense.memo}
         </span>
         {isMemoOverflowing && (
-          <Button
-            variant='ghost'
-            className='flex flex-row text-[13px] text-[#555] p-0 justify-start'
-            onClick={() => {
-              setIsMemoOpen(!isMemoOpen);
-            }}
-          >
-            더보기
-            <div
-              className={cn(isMemoOpen ? 'rotate-[90deg]' : 'rotate-[-90deg]')}
+          <div className='mt-1'>
+            <Button
+              variant='ghost'
+              className='flex flex-row h-auto text-[13px] text-[#555] p-0 justify-start has-[>svg]: p-0'
+              onClick={() => {
+                setIsMemoOpen(!isMemoOpen);
+              }}
             >
-              <ArrowLeft size={16} color='#555' />
-            </div>
-          </Button>
+              더보기
+              <div
+                className={cn(
+                  isMemoOpen ? 'rotate-[90deg]' : 'rotate-[-90deg]'
+                )}
+              >
+                <ArrowLeft size={16} color='#555' />
+              </div>
+            </Button>
+          </div>
         )}
       </div>
       <div className='flex flex-row flex-wrap gap-x-1 gap-y-1.5 mt-6 w-full'>

--- a/src/features/expense/ui/ReviewExpenseCard.tsx
+++ b/src/features/expense/ui/ReviewExpenseCard.tsx
@@ -1,0 +1,67 @@
+import { format } from 'date-fns';
+import { useLayoutEffect, useRef, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import CategoryTag from '@/features/category/ui/CategoryTag';
+import { Expense } from '@/features/expense/model/types/Expense';
+import ArrowLeft from '@/shared/ui/icons/ArrowLeft';
+import { cn } from '@/shared/ui/styles/utils';
+
+const ReviewExpenseCard: React.FC<{ expense: Expense }> = ({ expense }) => {
+  const memoRef = useRef<HTMLSpanElement>(null);
+  const [isMemoOverflowing, setIsMemoOverflowing] = useState<boolean>(false);
+  const [isMemoOpen, setIsMemoOpen] = useState<boolean>(false);
+
+  useLayoutEffect(() => {
+    const element = memoRef.current;
+    if (element) {
+      setIsMemoOverflowing(element.scrollHeight > element.clientHeight);
+    }
+  }, [memoRef]);
+
+  return (
+    <div className='flex flex-col w-full p-4 rounded-[8px] bg-white'>
+      <span aria-label='지출 날짜' className='text-[13px] text-[#999]'>
+        {format(expense.date, 'yyyy. M. d.')}
+      </span>
+      <span aria-label='지출 금액' className='text-[17px] font-semibold mt-1.5'>
+        {expense.amount.toLocaleString()}원
+      </span>
+      <div className='flex flex-col'>
+        <span
+          ref={memoRef}
+          aria-label='메모'
+          className={cn(
+            'text-[15px] text-[#555] leading-[150%] mt-2',
+            !isMemoOpen && 'line-clamp-1'
+          )}
+        >
+          {expense.memo}
+        </span>
+        {isMemoOverflowing && (
+          <Button
+            variant='ghost'
+            className='flex flex-row text-[13px] text-[#555] p-0 justify-start'
+            onClick={() => {
+              setIsMemoOpen(!isMemoOpen);
+            }}
+          >
+            더보기
+            <div
+              className={cn(isMemoOpen ? 'rotate-[90deg]' : 'rotate-[-90deg]')}
+            >
+              <ArrowLeft size={16} color='#555' />
+            </div>
+          </Button>
+        )}
+      </div>
+      <div className='flex flex-row flex-wrap gap-x-1 gap-y-1.5 mt-6 w-full'>
+        {expense.categories.map((cat) => (
+          <CategoryTag key={cat.uid} tagName={cat.name} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ReviewExpenseCard;

--- a/src/features/expense/ui/UnReviewedExpenseList/UnReviewedExpenseListItem.tsx
+++ b/src/features/expense/ui/UnReviewedExpenseList/UnReviewedExpenseListItem.tsx
@@ -1,10 +1,9 @@
 import { animated, type AnimatedProps, useSpring } from '@react-spring/web';
 import { useDrag } from '@use-gesture/react';
-import { format } from 'date-fns';
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
-import CategoryTag from '@/features/category/ui/CategoryTag';
 import { Expense } from '@/features/expense/model/types/Expense';
+import ReviewExpenseCard from '@/features/expense/ui/ReviewExpenseCard';
 import { cn } from '@/shared/ui/styles/utils';
 
 const AnimatedDiv = animated.div as React.FC<
@@ -90,28 +89,7 @@ const UnReviewedExpenseListItem: React.FC<Props> = ({
         }}
       >
         <div style={{ width: `${liWidth.toString()}px`, flexShrink: 0 }}>
-          <div className='flex flex-col w-full p-4 rounded-[8px] bg-white'>
-            <span aria-label='지출 날짜' className='text-[13px] text-[#999]'>
-              {format(expense.date, 'yyyy. M. d.')}
-            </span>
-            <span
-              aria-label='지출 금액'
-              className='text-[17px] font-semibold mt-1.5'
-            >
-              {expense.amount.toLocaleString()}원
-            </span>
-            <span
-              aria-label='메모'
-              className='text-[15px] text-[#555] leading-[150%] mt-2'
-            >
-              {expense.memo}
-            </span>
-            <div className='flex flex-row flex-wrap gap-x-1 gap-y-1.5 mt-6 w-full'>
-              {expense.categories.map((cat) => (
-                <CategoryTag key={cat.uid} tagName={cat.name} />
-              ))}
-            </div>
-          </div>
+          <ReviewExpenseCard expense={expense} />
         </div>
 
         <div style={{ width: '8px', flexShrink: 0 }} />


### PR DESCRIPTION
- 소요시간: 1시간 넘게..?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 지출 상세 정보를 보여주는 `ReviewExpenseCard` 컴포넌트가 추가되었습니다. 메모가 길 경우 한 줄로 줄여 보이며, "더보기" 버튼을 통해 전체 메모를 펼쳐볼 수 있습니다.
- **리팩터링**
  - 미검토 지출 항목에서 기존의 직접 렌더링 방식을 `ReviewExpenseCard` 컴포넌트 사용으로 변경하여 코드 일관성과 재사용성을 높였습니다.
- **스타일**
  - 메모 길이에 따라 줄임 처리 및 "더보기" 버튼이 동적으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->