### PR TITLE
 브라우저 가로가 640px 이상일 때 calendar이 깨지는 이슈

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -17,7 +17,7 @@ function Calendar({
       showOutsideDays={showOutsideDays}
       className={cn('p-3', className)}
       classNames={{
-        months: 'flex flex-col sm:flex-row gap-2',
+        months: 'flex flex-col gap-2',
         month: 'flex flex-col gap-4',
         caption: 'flex justify-center pt-1 relative items-center w-full',
         caption_label: 'text-sm font-medium',


### PR DESCRIPTION
- 소요시간: 10분
- 브라우저의 width가 sm(640px) 이상일 때 생기는 문제
- 우선순위: 낮음. hotfix 감인가?는 모르겠네요. 일단 수정해서 올립니다.