### PR TITLE
iOS 사파리에서 리뷰뷰 Drawer의 툴팁(helper text popover) 수정

### DIFF
--- a/src/features/expense/ui/ReviewExpenseDrawer.tsx
+++ b/src/features/expense/ui/ReviewExpenseDrawer.tsx
@@ -47,7 +47,7 @@ const RadioItem: React.FC<RadioItemProps> = ({
       <div className='flex flex-col'>
         <div className='flex flex-row items-center gap-1'>
           <span className='text-[15px] text-[#222] font-semibold'>{title}</span>
-          <Popover>
+          <Popover modal={true}>
             <PopoverTrigger>
               <div className='rotate-180'>
                 <Exclamation size={16} color='#999' />


### PR DESCRIPTION
- 소요시간: 20분
- shadcn/ui 이슈의 댓글 참고하여 해결
  - https://github.com/shadcn-ui/ui/issues/3516#issuecomment-2312148856

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 팝오버(Popover) 동작이 모달 방식으로 변경되어, 열려 있을 때 다른 영역과의 상호작용이 차단됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->