### PR TITLE
api date range 추가, count api 추가, 리뷰/회고 페이지 로직 업데이트

### DIFF
--- a/src/features/expense/api/useExpenseQuery.ts
+++ b/src/features/expense/api/useExpenseQuery.ts
@@ -278,7 +278,7 @@ export const useTotalAmountByPeriod = (period: Period) => {
   return { totalAmount, isLoading, error };
 };
 
-export const useCountByStartEnd = ({
+export const useExpenseCountByStartEnd = ({
   start,
   end,
 }: {
@@ -289,12 +289,15 @@ export const useCountByStartEnd = ({
     queryKey: ['expense-count'],
     queryFn: async () => {
       try {
-        const res = await userAxios.get<{ expense_count: number }>(baseUrl, {
-          params: {
-            start_date: formatDate(start, 'yyyy-MM-dd'),
-            end_date: formatDate(end, 'yyyy-MM-dd'),
-          },
-        });
+        const res = await userAxios.get<{ expense_count: number }>(
+          baseUrl + '/counts',
+          {
+            params: {
+              start_date: formatDate(start, 'yyyy-MM-dd'),
+              end_date: formatDate(end, 'yyyy-MM-dd'),
+            },
+          }
+        );
 
         return res.data.expense_count;
       } catch (error) {

--- a/src/features/expense/api/useExpenseQuery.ts
+++ b/src/features/expense/api/useExpenseQuery.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
+import { formatDate } from 'date-fns';
 import { useMemo } from 'react';
 
 import { apiUrl } from '@/features/common/consts';
@@ -50,6 +51,41 @@ export const useExpenses = ({
           convertServerExpenseToExpense(serverExpense)
         );
 
+        return expenses;
+      } catch (error) {
+        if (error instanceof AxiosError) {
+          throw new Error('지출 목록 조회 실패: ' + error.message);
+        }
+        throw error;
+      }
+    },
+  });
+};
+
+export const useExpensesByStartEnd = ({
+  start,
+  end,
+  consumptionKind,
+}: {
+  start: Date;
+  end: Date;
+  consumptionKind: ConsumptionKind;
+}) => {
+  return useQuery<Expense[]>({
+    queryKey: [...queryKeys.expenses, start, end],
+    queryFn: async () => {
+      try {
+        const res = await userAxios.get(baseUrl, {
+          params: {
+            start_date: formatDate(start, 'yyyy-MM-dd'),
+            end_date: formatDate(end, 'yyyy-MM-dd'),
+            consumption_kind: consumptionKind,
+          },
+        });
+        const serverExpenses = res.data as ServerExpense[];
+        const expenses = serverExpenses.map((serverExpense) =>
+          convertServerExpenseToExpense(serverExpense)
+        );
         return expenses;
       } catch (error) {
         if (error instanceof AxiosError) {
@@ -240,4 +276,33 @@ export const useTotalAmountByPeriod = (period: Period) => {
   );
 
   return { totalAmount, isLoading, error };
+};
+
+export const useCountByStartEnd = ({
+  start,
+  end,
+}: {
+  start: Date;
+  end: Date;
+}) => {
+  return useQuery<number>({
+    queryKey: ['expense-count'],
+    queryFn: async () => {
+      try {
+        const res = await userAxios.get<{ expense_count: number }>(baseUrl, {
+          params: {
+            start_date: formatDate(start, 'yyyy-MM-dd'),
+            end_date: formatDate(end, 'yyyy-MM-dd'),
+          },
+        });
+
+        return res.data.expense_count;
+      } catch (error) {
+        if (error instanceof AxiosError) {
+          throw new Error('지출 개수 조회 실패' + error.message);
+        }
+        throw error;
+      }
+    },
+  });
 };

--- a/src/features/expense/api/useExpenseQuery.ts
+++ b/src/features/expense/api/useExpenseQuery.ts
@@ -286,7 +286,7 @@ export const useExpenseCountByRange = ({
   end: Date;
 }) => {
   return useQuery<number>({
-    queryKey: ['expense-count'],
+    queryKey: ['expense-count', start, end],
     queryFn: async () => {
       try {
         const res = await userAxios.get<{ expense_count: number }>(

--- a/src/features/expense/api/useExpenseQuery.ts
+++ b/src/features/expense/api/useExpenseQuery.ts
@@ -62,7 +62,7 @@ export const useExpenses = ({
   });
 };
 
-export const useExpensesByStartEnd = ({
+export const useExpensesByRange = ({
   start,
   end,
   consumptionKind,
@@ -72,7 +72,7 @@ export const useExpensesByStartEnd = ({
   consumptionKind: ConsumptionKind;
 }) => {
   return useQuery<Expense[]>({
-    queryKey: [...queryKeys.expenses, start, end],
+    queryKey: [...queryKeys.expenses, start, end, consumptionKind],
     queryFn: async () => {
       try {
         const res = await userAxios.get(baseUrl, {
@@ -278,7 +278,7 @@ export const useTotalAmountByPeriod = (period: Period) => {
   return { totalAmount, isLoading, error };
 };
 
-export const useExpenseCountByStartEnd = ({
+export const useExpenseCountByRange = ({
   start,
   end,
 }: {

--- a/src/features/expense/api/useExpenseQuery.ts
+++ b/src/features/expense/api/useExpenseQuery.ts
@@ -80,14 +80,14 @@ export const useExpensesByRange = ({
     ],
     queryFn: async () => {
       try {
-        const res = await userAxios.get(baseUrl, {
+        const res = await userAxios.get<ServerExpense[]>(baseUrl, {
           params: {
             start_date: formatDate(start, 'yyyy-MM-dd'),
             end_date: formatDate(end, 'yyyy-MM-dd'),
             consumption_kind: consumptionKind,
           },
         });
-        const serverExpenses = res.data as ServerExpense[];
+        const serverExpenses = res.data;
         const expenses = serverExpenses.map((serverExpense) =>
           convertServerExpenseToExpense(serverExpense)
         );

--- a/src/features/expense/api/useExpenseQuery.ts
+++ b/src/features/expense/api/useExpenseQuery.ts
@@ -72,7 +72,12 @@ export const useExpensesByRange = ({
   consumptionKind: ConsumptionKind;
 }) => {
   return useQuery<Expense[]>({
-    queryKey: [...queryKeys.expenses, start, end, consumptionKind],
+    queryKey: [
+      ...queryKeys.expenses,
+      start.toISOString(),
+      end.toISOString(),
+      consumptionKind,
+    ],
     queryFn: async () => {
       try {
         const res = await userAxios.get(baseUrl, {
@@ -286,7 +291,7 @@ export const useExpenseCountByRange = ({
   end: Date;
 }) => {
   return useQuery<number>({
-    queryKey: ['expense-count', start, end],
+    queryKey: ['expense-count', start.toISOString(), end.toISOString()],
     queryFn: async () => {
       try {
         const res = await userAxios.get<{ expense_count: number }>(

--- a/src/features/expense/model/types/utils.ts
+++ b/src/features/expense/model/types/utils.ts
@@ -10,9 +10,6 @@ export const convertExpenseToServerExpense = (
     getDateOnly(expendedDate)
   ).toISOString();
 
-  console.log(expendedDate);
-  console.log(expended_at);
-
   const serverExpense: ServerExpense = {
     uid: uid ?? '',
     expended_at,

--- a/src/features/expense/ui/UnReviewedExpenseView.tsx
+++ b/src/features/expense/ui/UnReviewedExpenseView.tsx
@@ -2,7 +2,8 @@ import React, { useLayoutEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import {
-  useExpenses,
+  useExpenseCountByStartEnd,
+  useExpensesByStartEnd,
   useUpdateExpense,
 } from '@/features/expense/api/useExpenseQuery';
 import { ConsumptionKind } from '@/features/expense/model/types/ConsumptionKind';
@@ -66,13 +67,18 @@ interface Props {
 const UnReviewedExpenseView: React.FC<Props> = ({ onMoveRetrospective }) => {
   const updateExpense = useUpdateExpense();
 
-  const { data: totalExpenses = [] } = useExpenses({
-    period: { year: 2025, month: 4 },
+  const start = new Date('2025-04-12');
+  const end = new Date('2025-04-18');
+
+  const { data: totalExpenseCount = 0 } = useExpenseCountByStartEnd({
+    start,
+    end,
   });
 
-  const { data: unReviewedExpenses = [] } = useExpenses({
-    period: { year: 2025, month: 4 },
-    consumptionKind: 'none',
+  const { data: unReviewedExpenses = [] } = useExpensesByStartEnd({
+    start,
+    end,
+    consumptionKind: ConsumptionKind.none,
   });
 
   const [selectedExpense, setSelectedExpense] = useState<Expense | null>(null);
@@ -126,7 +132,7 @@ const UnReviewedExpenseView: React.FC<Props> = ({ onMoveRetrospective }) => {
       />
       {/* when scrollable height, pr-5. when not scrollable height, pr-4 (scroll width - 4px) */}
       <div className='relative flex flex-col flex-1 bg-[#f5f3f0] pl-5 pr-4 pt-8 overflow-y-auto scroll'>
-        {totalExpenses.length === 0 ? (
+        {totalExpenseCount === 0 ? (
           <TotalExpenseEmptyPlaceholder />
         ) : (
           <>

--- a/src/features/expense/ui/UnReviewedExpenseView.tsx
+++ b/src/features/expense/ui/UnReviewedExpenseView.tsx
@@ -2,8 +2,8 @@ import React, { useLayoutEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import {
-  useExpenseCountByStartEnd,
-  useExpensesByStartEnd,
+  useExpenseCountByRange,
+  useExpensesByRange,
   useUpdateExpense,
 } from '@/features/expense/api/useExpenseQuery';
 import { ConsumptionKind } from '@/features/expense/model/types/ConsumptionKind';
@@ -70,12 +70,12 @@ const UnReviewedExpenseView: React.FC<Props> = ({ onMoveRetrospective }) => {
   const start = new Date('2025-04-12');
   const end = new Date('2025-04-18');
 
-  const { data: totalExpenseCount = 0 } = useExpenseCountByStartEnd({
+  const { data: totalExpenseCount = 0 } = useExpenseCountByRange({
     start,
     end,
   });
 
-  const { data: unReviewedExpenses = [] } = useExpensesByStartEnd({
+  const { data: unReviewedExpenses = [] } = useExpensesByRange({
     start,
     end,
     consumptionKind: ConsumptionKind.none,

--- a/src/features/expense/ui/UnReviewedExpenseView.tsx
+++ b/src/features/expense/ui/UnReviewedExpenseView.tsx
@@ -9,6 +9,7 @@ import {
 import { ConsumptionKind } from '@/features/expense/model/types/ConsumptionKind';
 import { Expense } from '@/features/expense/model/types/Expense';
 import { getConsumptionTitle } from '@/features/expense/utils';
+import useDateRange from '@/shared/lib/useDateRange';
 import { cn } from '@/shared/ui/styles/utils';
 
 import ReviewExpenseDrawer from './ReviewExpenseDrawer';
@@ -67,8 +68,9 @@ interface Props {
 const UnReviewedExpenseView: React.FC<Props> = ({ onMoveRetrospective }) => {
   const updateExpense = useUpdateExpense();
 
-  const start = new Date('2025-04-12');
-  const end = new Date('2025-04-18');
+  const {
+    dateRange: { start, end },
+  } = useDateRange();
 
   const { data: totalExpenseCount = 0 } = useExpenseCountByRange({
     start,

--- a/src/features/retrospective/api/useRetrospective.ts
+++ b/src/features/retrospective/api/useRetrospective.ts
@@ -11,7 +11,7 @@ import userAxios from '@/shared/api/userAxios';
 
 import { fromServerRetrospective } from '../model/utils';
 
-export const useRetrospectivesByStartEnd = ({
+export const useRetrospectivesByRange = ({
   start,
   end,
 }: {

--- a/src/features/retrospective/api/useRetrospective.ts
+++ b/src/features/retrospective/api/useRetrospective.ts
@@ -19,7 +19,7 @@ export const useRetrospectivesByRange = ({
   end: Date;
 }) => {
   return useQuery<Retrospective[]>({
-    queryKey: ['retrospective'],
+    queryKey: ['retrospective', start, end],
     queryFn: async () => {
       try {
         const res = await userAxios.get<ServerRetrospective[]>(

--- a/src/features/retrospective/api/useRetrospective.ts
+++ b/src/features/retrospective/api/useRetrospective.ts
@@ -1,8 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
+import { formatDate } from 'date-fns';
 
 import { apiUrl } from '@/features/common/consts';
-import { getDateOnly } from '@/features/expense/model/types/utils';
 import {
   Retrospective,
   ServerRetrospective,
@@ -11,12 +11,12 @@ import userAxios from '@/shared/api/userAxios';
 
 import { fromServerRetrospective } from '../model/utils';
 
-const useRetrospectivesByPeriod = ({
-  startDate,
-  endDate,
+export const useRetrospectivesByStartEnd = ({
+  start,
+  end,
 }: {
-  startDate: Date;
-  endDate: Date;
+  start: Date;
+  end: Date;
 }) => {
   return useQuery<Retrospective[]>({
     queryKey: ['retrospective'],
@@ -26,8 +26,8 @@ const useRetrospectivesByPeriod = ({
           apiUrl + '/expense/expenses/consumption-retrospective',
           {
             params: {
-              start_date: getDateOnly(startDate),
-              end_date: getDateOnly(endDate),
+              start_date: formatDate(start, 'yyyy-MM-dd'),
+              end_date: formatDate(end, 'yyyy-MM-dd'),
             },
           }
         );
@@ -45,5 +45,3 @@ const useRetrospectivesByPeriod = ({
     },
   });
 };
-
-export default useRetrospectivesByPeriod;

--- a/src/features/retrospective/api/useRetrospective.ts
+++ b/src/features/retrospective/api/useRetrospective.ts
@@ -19,7 +19,7 @@ export const useRetrospectivesByRange = ({
   end: Date;
 }) => {
   return useQuery<Retrospective[]>({
-    queryKey: ['retrospective', start, end],
+    queryKey: ['retrospective', start.toISOString(), end.toISOString()],
     queryFn: async () => {
       try {
         const res = await userAxios.get<ServerRetrospective[]>(

--- a/src/features/retrospective/api/useRetrospectivesByPeriod.ts
+++ b/src/features/retrospective/api/useRetrospectivesByPeriod.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 import { apiUrl } from '@/features/common/consts';
+import { getDateOnly } from '@/features/expense/model/types/utils';
 import {
   Retrospective,
   ServerRetrospective,
@@ -10,13 +11,25 @@ import userAxios from '@/shared/api/userAxios';
 
 import { fromServerRetrospective } from '../model/utils';
 
-export const useRetrospectives = () => {
+const useRetrospectivesByPeriod = ({
+  startDate,
+  endDate,
+}: {
+  startDate: Date;
+  endDate: Date;
+}) => {
   return useQuery<Retrospective[]>({
     queryKey: ['retrospective'],
     queryFn: async () => {
       try {
         const res = await userAxios.get<ServerRetrospective[]>(
-          apiUrl + '/expense/expenses/consumption-retrospective'
+          apiUrl + '/expense/expenses/consumption-retrospective',
+          {
+            params: {
+              start_date: getDateOnly(startDate),
+              end_date: getDateOnly(endDate),
+            },
+          }
         );
 
         const retrospectives = res.data.map((serverRetrospective) =>
@@ -32,3 +45,5 @@ export const useRetrospectives = () => {
     },
   });
 };
+
+export default useRetrospectivesByPeriod;

--- a/src/features/retrospective/ui/RetrospectiveView.tsx
+++ b/src/features/retrospective/ui/RetrospectiveView.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/features/expense/consts';
 import { ConsumptionKind } from '@/features/expense/model/types/ConsumptionKind';
 import { useRetrospectivesByRange } from '@/features/retrospective/api/useRetrospective';
+import useDateRange from '@/shared/lib/useDateRange';
 
 import RetrospectiveCard from './RetrospectiveCard';
 import RetrospectiveDetailPopover from './RetrospectiveDetailPopover';
@@ -14,9 +15,13 @@ import RetrospectiveDetailPopover from './RetrospectiveDetailPopover';
 const RetrospectiveView: React.FC<{ onMoveReview: () => void }> = ({
   onMoveReview,
 }) => {
+  const {
+    dateRange: { start, end },
+  } = useDateRange();
+
   const { data: retrospectives = [] } = useRetrospectivesByRange({
-    start: new Date('2025-04-12'),
-    end: new Date('2025-04-18'),
+    start,
+    end,
   });
 
   const [consumptionKind, setConsumptionKind] =

--- a/src/features/retrospective/ui/RetrospectiveView.tsx
+++ b/src/features/retrospective/ui/RetrospectiveView.tsx
@@ -7,7 +7,7 @@ import {
   consumptionEssential,
 } from '@/features/expense/consts';
 import { ConsumptionKind } from '@/features/expense/model/types/ConsumptionKind';
-import { useRetrospectives } from '@/features/retrospective/api/useRetrospectives';
+import useRetrospectivesByPeriod from '@/features/retrospective/api/useRetrospectivesByPeriod';
 
 import RetrospectiveCard from './RetrospectiveCard';
 import RetrospectiveDetailPopover from './RetrospectiveDetailPopover';
@@ -18,7 +18,10 @@ const RetrospectiveView: React.FC<{ onMoveReview: () => void }> = ({
   const { data: totalExpenses } = useExpenses({
     period: { year: 2025, month: 4 },
   });
-  const { data: retrospectives } = useRetrospectives();
+  const { data: retrospectives } = useRetrospectivesByPeriod({
+    startDate: new Date(2025, 4, 12),
+    endDate: new Date(2025, 4, 18),
+  });
 
   const [consumptionKind, setConsumptionKind] =
     useState<ConsumptionKind | null>(null);

--- a/src/features/retrospective/ui/RetrospectiveView.tsx
+++ b/src/features/retrospective/ui/RetrospectiveView.tsx
@@ -7,7 +7,7 @@ import {
   consumptionEssential,
 } from '@/features/expense/consts';
 import { ConsumptionKind } from '@/features/expense/model/types/ConsumptionKind';
-import useRetrospectivesByPeriod from '@/features/retrospective/api/useRetrospectivesByPeriod';
+import { useRetrospectivesByStartEnd } from '@/features/retrospective/api/useRetrospective';
 
 import RetrospectiveCard from './RetrospectiveCard';
 import RetrospectiveDetailPopover from './RetrospectiveDetailPopover';
@@ -18,9 +18,10 @@ const RetrospectiveView: React.FC<{ onMoveReview: () => void }> = ({
   const { data: totalExpenses } = useExpenses({
     period: { year: 2025, month: 4 },
   });
-  const { data: retrospectives } = useRetrospectivesByPeriod({
-    startDate: new Date(2025, 4, 12),
-    endDate: new Date(2025, 4, 18),
+
+  const { data: retrospectives } = useRetrospectivesByStartEnd({
+    start: new Date('2025-04-12'),
+    end: new Date('2025-04-18'),
   });
 
   const [consumptionKind, setConsumptionKind] =

--- a/src/features/retrospective/ui/RetrospectiveView.tsx
+++ b/src/features/retrospective/ui/RetrospectiveView.tsx
@@ -1,13 +1,12 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
-import { useExpenses } from '@/features/expense/api/useExpenseQuery';
 import {
   consumptionConscious,
   consumptionEmotional,
   consumptionEssential,
 } from '@/features/expense/consts';
 import { ConsumptionKind } from '@/features/expense/model/types/ConsumptionKind';
-import { useRetrospectivesByStartEnd } from '@/features/retrospective/api/useRetrospective';
+import { useRetrospectivesByRange } from '@/features/retrospective/api/useRetrospective';
 
 import RetrospectiveCard from './RetrospectiveCard';
 import RetrospectiveDetailPopover from './RetrospectiveDetailPopover';
@@ -15,11 +14,7 @@ import RetrospectiveDetailPopover from './RetrospectiveDetailPopover';
 const RetrospectiveView: React.FC<{ onMoveReview: () => void }> = ({
   onMoveReview,
 }) => {
-  const { data: totalExpenses } = useExpenses({
-    period: { year: 2025, month: 4 },
-  });
-
-  const { data: retrospectives } = useRetrospectivesByStartEnd({
+  const { data: retrospectives = [] } = useRetrospectivesByRange({
     start: new Date('2025-04-12'),
     end: new Date('2025-04-18'),
   });
@@ -28,17 +23,17 @@ const RetrospectiveView: React.FC<{ onMoveReview: () => void }> = ({
     useState<ConsumptionKind | null>(null);
   const [open, setOpen] = useState<boolean>(false);
 
-  if (!retrospectives) {
-    return null;
-  }
+  const [reviewedExpenseCount, setReviewedExpenseCount] = useState<number>(0);
 
-  if (!totalExpenses) {
-    return;
-  }
+  useEffect(() => {
+    setReviewedExpenseCount(
+      retrospectives.reduce((acc, cur) => acc + cur.totalCount, 0)
+    );
+  }, [retrospectives]);
 
   return (
     <div className='flex-1 flex flex-col overflow-y-auto scroll'>
-      {totalExpenses.length === 0 ? (
+      {reviewedExpenseCount === 0 ? (
         <div className='flex-1 flex flex-col items-center justify-center text-center'>
           <span className='text-[15px] text-[#555] leading-[150%]'>
             아직 리뷰한 소비가 없어요.

--- a/src/shared/lib/useDateRange.ts
+++ b/src/shared/lib/useDateRange.ts
@@ -1,0 +1,10 @@
+import { useState } from 'react';
+
+export default function useDateRange() {
+  const [dateRange, setDateRange] = useState<{ start: Date; end: Date }>({
+    start: new Date('2025-04-12'),
+    end: new Date('2025-04-18'),
+  });
+
+  return { dateRange, setDateRange };
+}

--- a/src/shared/lib/useDateRange.ts
+++ b/src/shared/lib/useDateRange.ts
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 
 export default function useDateRange() {
-  const [dateRange, setDateRange] = useState<{ start: Date; end: Date }>({
+  const [dateRange] = useState<{ start: Date; end: Date }>({
     start: new Date('2025-04-12'),
     end: new Date('2025-04-18'),
   });
 
-  return { dateRange, setDateRange };
+  return { dateRange };
 }


### PR DESCRIPTION
- 소요시간: 30분
- api date range 추가에 대응
- useExpenseCount 추가
- 리뷰 및 회고 페이지에서 로직 업데이트
- p.s. 기존 `Period` 타입 리팩토링 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
	- 날짜 범위와 소비 유형으로 지출 내역을 조회할 수 있는 기능이 추가되었습니다.
	- 선택한 날짜 범위 내 지출 건수를 확인할 수 있는 기능이 추가되었습니다.
	- 날짜 범위로 회고 내역을 조회할 수 있는 기능이 추가되었습니다.
	- 고정된 날짜 대신 동적 날짜 범위를 사용하는 새로운 날짜 범위 훅이 도입되었습니다.
- **버그 수정**
	- 지출 데이터 변환 시 불필요한 콘솔 로그가 제거되었습니다.
- **리팩터**
	- 일부 컴포넌트가 월별 조회에서 날짜 범위 기반 조회로 변경되었습니다.
	- 회고 조회 관련 훅이 날짜 범위 기반으로 리팩터링되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->