### PR TITLE
fix: counts url in useExpenseCount

### DIFF
--- a/src/features/expense/api/useExpenseQuery.ts
+++ b/src/features/expense/api/useExpenseQuery.ts
@@ -295,7 +295,7 @@ export const useExpenseCountByRange = ({
     queryFn: async () => {
       try {
         const res = await userAxios.get<{ expense_count: number }>(
-          baseUrl + '/counts',
+          baseUrl + 'counts',
           {
             params: {
               start_date: formatDate(start, 'yyyy-MM-dd'),


### PR DESCRIPTION
- `useExpenseCount` 쿼리에서 요청 url이 `expense/expenses//counts` 되는 문제
  - 다행히 `//counts` 에서도 정상작동중.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 날짜 범위 내 지출 건수를 조회할 때 잘못된 URL로 인해 발생하던 오류를 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->