### PR TITLE
S23 InputCategoryTags 추가 버튼 오류 수정

### DIFF
--- a/src/features/category/ui/InputCategoryTags/InputCategoryTags.tsx
+++ b/src/features/category/ui/InputCategoryTags/InputCategoryTags.tsx
@@ -41,14 +41,16 @@ const InputCategoryTags = React.forwardRef<
       className={cn(
         // caveat: :has() variant requires tailwind v3.4 or above: https://tailwindcss.com/blog/tailwindcss-v3-4#new-has-variant
         'has-[:focus-visible]:border-[#555]',
-        'min-h-12 flex flex-row w-full',
+        'min-h-12 w-full',
         'flex flex-row items-center rounded-md border border-[#ccc] bg-white px-4 py-3 text-[15px] ring-offset-white',
         'disabled:cursor-not-allowed disabled:opacity-50',
         'focus-visible:border-[#555555]',
         className
       )}
     >
-      <div className={cn('flex flex-row flex-1 flex-wrap gap-[8px] mr-5')}>
+      <div
+        className={cn('flex flex-row flex-1 flex-wrap gap-[8px] mr-5 min-w-0')}
+      >
         {value.map((item) => (
           <CategoryTag
             key={item}
@@ -61,7 +63,7 @@ const InputCategoryTags = React.forwardRef<
         ))}
         {value.length >= 0 && value.length < 3 && (
           <input
-            className='flex-1 outline-none placeholder:text-[#999] placeholder:text-[15px]'
+            className='flex-1 outline-none placeholder:text-[#999] placeholder:text-[15px] min-w-0'
             aria-label='카테고리 추가 입력'
             value={pendingDataPoint}
             placeholder={value.length === 0 ? placeholder : undefined}


### PR DESCRIPTION
- #190 
- 소요시간: 15분
- min-w-0을 `CategoryTag wrapper`, `input`에 추가

작업전
<img width="385" height="716" alt="image" src="https://github.com/user-attachments/assets/60b83259-5dd6-409f-89cc-d36748092804" />

작업 후
<img width="393" alt="image" src="https://github.com/user-attachments/assets/f0323c33-3059-460e-b156-f7e07a98a687" />
<img width="393" alt="image" src="https://github.com/user-attachments/assets/08d3db4d-3b57-4b72-b290-499d93c3b797" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 레이아웃 클래스를 정리하여 불필요한 flex 클래스를 제거하고, 태그 래퍼 및 입력 필드에 min-w-0 클래스를 추가하여 입력 영역이 컨테이너를 넘지 않도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->