### PR TITLE
Toaster에 duration 2000 추가

### DIFF
--- a/src/shared/ui/Toaster/Toaster.tsx
+++ b/src/shared/ui/Toaster/Toaster.tsx
@@ -26,6 +26,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
           ),
           title: 'text-[13px] text-white',
         },
+        duration: 2000,
       }}
       style={
         {


### PR DESCRIPTION
default 4000에서 2000으로 변경.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 모든 토스트 알림의 표시 시간이 2초(2000ms)로 고정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->