### PR TITLE
Clarity 코드 업데이트 및 staff identify 추가

### DIFF
--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -1,7 +1,7 @@
 import 'pretendard/dist/web/static/pretendard.css';
 import './index.css';
 
-// import Clarity from '@microsoft/clarity';
+import Clarity from '@microsoft/clarity';
 // tanstack-query
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
@@ -21,25 +21,11 @@ declare module '@tanstack/react-router' {
     router: typeof router;
   }
 }
-function insertClarity(key: string) {
-  const clarityScript = document.createElement('script');
-  clarityScript.async = true;
-  clarityScript.src = `https://www.clarity.ms/tag/${key}`;
-  document.head.appendChild(clarityScript);
-
-  // window.clarity 초기화
-  (window as any).clarity =
-    (window as any).clarity ||
-    function (...args: any[]) {
-      ((window as any).clarity.q = (window as any).clarity.q || []).push(args);
-    };
-}
 
 if (import.meta.env.PROD) {
   const CLARITY_KEY = import.meta.env.VITE_CLARITY_KEY as string;
 
-  // Clarity.init(CLARITY_KEY);
-  insertClarity(CLARITY_KEY);
+  Clarity.init(CLARITY_KEY);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/features/auth/ui/AuthGuard.tsx
+++ b/src/features/auth/ui/AuthGuard.tsx
@@ -1,3 +1,4 @@
+import Clarity from '@microsoft/clarity';
 import { useLocation, useNavigate } from '@tanstack/react-router';
 import { AxiosError } from 'axios';
 import React from 'react';
@@ -33,6 +34,11 @@ const AuthGuard: React.FC<{
             void navigate({ to: '/settings/account' });
             return;
           }
+
+          if (user.isStaff) {
+            Clarity.identify('staff');
+          }
+
           setIsAuthorized(true);
         }
       } catch (error) {


### PR DESCRIPTION
- 소요시간: 20분 + 고민 및 뻘짓 4시간?
- Clarity init을 npm 패키지로 변경
- `AuthGuard`의 `getMe` 로직에서 `is_staff === true`일 때 `clarity.identify('staff)` 호출
  - 추가 작업: 백엔드에서 운영진 데이터에 is_staff 설정 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 인증된 스태프 사용자를 위한 Clarity 식별 기능이 추가되었습니다.

- **리팩터**
    - Clarity 통합 방식이 공식 메서드 사용으로 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->