### PR TITLE
localhost에서 Clarity.identify 오류 해결

### DIFF
--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -26,6 +26,7 @@ if (import.meta.env.PROD) {
   const CLARITY_KEY = import.meta.env.VITE_CLARITY_KEY as string;
 
   Clarity.init(CLARITY_KEY);
+  window.__clarityInitialized = true;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/features/auth/ui/AuthGuard.tsx
+++ b/src/features/auth/ui/AuthGuard.tsx
@@ -35,7 +35,7 @@ const AuthGuard: React.FC<{
             return;
           }
 
-          if (user.isStaff) {
+          if (user.isStaff && window.__clarityInitialized) {
             Clarity.identify('staff');
           }
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,4 +1,0 @@
-declare module '*.html?raw' {
-  const content: string;
-  export default content;
-}

--- a/src/shared/types/global.d.ts
+++ b/src/shared/types/global.d.ts
@@ -1,0 +1,7 @@
+export {};
+
+declare global {
+  interface Window {
+    __clarityInitialized?: boolean;
+  }
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -41,7 +41,8 @@
     "vitest.setup.ts",
     // playwright
     "**.spec.ts",
-    "playwright.config.ts"
+    "playwright.config.ts",
+    "src/shared/types/global.d.ts"
   ],
   "exclude": [
     "e2e"


### PR DESCRIPTION
- 소요시간: 20분

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - Microsoft Clarity가 초기화된 경우에만 직원 사용자의 Clarity 식별이 수행되도록 개선되었습니다.

- **문서**
  - 글로벌 타입 선언 파일 위치가 변경되어 TypeScript에서 Clarity 초기화 플래그를 올바르게 인식합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->