### PR TITLE
Clarity.identify를 모든 AuthGuard 에서 실행하도록 수정

### DIFF
--- a/src/features/auth/ui/AuthGuard.tsx
+++ b/src/features/auth/ui/AuthGuard.tsx
@@ -55,7 +55,7 @@ const AuthGuard: React.FC<{
     };
 
     void checkAuth();
-  }, [navigate]);
+  }, [navigate, location.pathname]);
 
   if (loading) {
     return <FullScreenSpinner />;

--- a/src/features/auth/ui/AuthGuard.tsx
+++ b/src/features/auth/ui/AuthGuard.tsx
@@ -13,7 +13,7 @@ const AuthGuard: React.FC<{
   children?: React.ReactNode;
 }> = ({ children }) => {
   const navigate = useNavigate();
-  const location = useLocation();
+  const pathname = useLocation({ select: (location) => location.pathname });
 
   const [isAuthorized, setIsAuthorized] = React.useState<boolean>(false);
   const [loading, setLoading] = React.useState<boolean>(true);
@@ -27,10 +27,7 @@ const AuthGuard: React.FC<{
         const user = toUser(res.data);
 
         if (res.status === 200) {
-          if (
-            location.pathname !== '/settings/account' &&
-            !user.nickname?.trim()
-          ) {
+          if (pathname !== '/settings/account' && !user.nickname?.trim()) {
             void navigate({ to: '/settings/account' });
             return;
           }
@@ -55,7 +52,7 @@ const AuthGuard: React.FC<{
     };
 
     void checkAuth();
-  }, [navigate, location.pathname]);
+  }, [navigate, pathname]);
 
   if (loading) {
     return <FullScreenSpinner />;


### PR DESCRIPTION
- 소요시간: 30분
- `useEffect`의 `dependency array`에 `location.pathname` 추가
- 모든 페이지마다 `Clarity.identify` 함수 호출이 필요함
  - https://github.com/microsoft/clarity/issues/384#issuecomment-1549994702

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **버그 수정**
  - 인증 상태 확인이 현재 URL 경로 변경 시에도 올바르게 동작하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->