### PR TITLE
지출내역의 메모가 공백없이 길 경우 카드 밖으로 넘치는 현상 수정

### DIFF
--- a/src/features/expense/ui/DailyExpenseRecord/DailyExpenseRecord.tsx
+++ b/src/features/expense/ui/DailyExpenseRecord/DailyExpenseRecord.tsx
@@ -23,7 +23,10 @@ const DailyExpenseRecord: React.FC<Omit<Expense, 'date'>> = ({
       <p aria-label='지출 금액' className='text-[15px] font-semibold'>
         {amount.toLocaleString()}원
       </p>
-      <p aria-label='메모' className='text-[15px] leading-[150%] mt-2'>
+      <p
+        aria-label='메모'
+        className='text-[15px] leading-[150%] mt-2 break-words'
+      >
         {memo}
       </p>
       <div className='flex flex-row flex-wrap gap-x-1 gap-y-1.5 mt-6 w-full'>

--- a/src/features/expense/ui/ReviewExpenseCard/ReviewExpenseCard.tsx
+++ b/src/features/expense/ui/ReviewExpenseCard/ReviewExpenseCard.tsx
@@ -42,7 +42,7 @@ const ReviewExpenseCard: React.FC<{ expense: Expense }> = ({ expense }) => {
           ref={memoRef}
           aria-label='메모'
           className={cn(
-            'text-[15px] text-[#555] leading-[150%] mt-1',
+            'text-[15px] text-[#555] leading-[150%] mt-1 break-words',
             !isMemoOpen && 'line-clamp-1'
           )}
         >


### PR DESCRIPTION
- #224 
- 5분
- `break-words` 속성을 주어 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 메모 텍스트가 너무 길 경우 자동으로 줄바꿈되어 화면 넘침이나 가로 스크롤이 발생하지 않도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->