### PR TITLE
fix: 회고 디테일 페이지 깨짐 현상 수정

### DIFF
--- a/src/features/retrospective/ui/RetrospectiveView.tsx
+++ b/src/features/retrospective/ui/RetrospectiveView.tsx
@@ -37,71 +37,73 @@ const RetrospectiveView: React.FC<{ onMoveReview: () => void }> = ({
   }, [retrospectives]);
 
   return (
-    <div className='flex-1 flex flex-col overflow-y-auto scroll'>
-      {reviewedExpenseCount === 0 ? (
-        <div className='flex-1 flex flex-col items-center justify-center text-center'>
-          <span className='text-[15px] text-[#555] leading-[150%]'>
-            아직 리뷰한 소비가 없어요.
-            <br />
-            리뷰 탭으로 이동해 소비를 분류해주세요.
-          </span>
-          <button
-            className='text-[13px] text-[#555] rounded-full px-3 py-2 bg-[#efefef] mt-4'
-            onClick={onMoveReview}
-          >
-            리뷰 탭으로 이동하기
-          </button>
-        </div>
-      ) : (
-        <>
-          {open && consumptionKind && (
-            <RetrospectiveDetailPopoverPage
-              consumptionKind={consumptionKind}
-              onClose={() => {
-                setOpen(false);
-                setConsumptionKind(null);
+    <>
+      {open && consumptionKind && (
+        <RetrospectiveDetailPopoverPage
+          consumptionKind={consumptionKind}
+          onClose={() => {
+            setOpen(false);
+            setConsumptionKind(null);
+          }}
+        />
+      )}
+      <div className='flex-1 flex flex-col overflow-y-auto scroll'>
+        {reviewedExpenseCount === 0 ? (
+          <div className='flex-1 flex flex-col items-center justify-center text-center'>
+            <span className='text-[15px] text-[#555] leading-[150%]'>
+              아직 리뷰한 소비가 없어요.
+              <br />
+              리뷰 탭으로 이동해 소비를 분류해주세요.
+            </span>
+            <button
+              className='text-[13px] text-[#555] rounded-full px-3 py-2 bg-[#efefef] mt-4'
+              onClick={onMoveReview}
+            >
+              리뷰 탭으로 이동하기
+            </button>
+          </div>
+        ) : (
+          <>
+            <RetrospectiveCard
+              consumption={consumptionEmotional}
+              retrospective={retrospectives.find(
+                (retrospective) =>
+                  retrospective.consumptionKind === ConsumptionKind.emotional
+              )}
+              onClickRetrospectiveDetail={() => {
+                setConsumptionKind(ConsumptionKind.emotional);
+                setOpen(true);
               }}
             />
-          )}
-          <RetrospectiveCard
-            consumption={consumptionEmotional}
-            retrospective={retrospectives.find(
-              (retrospective) =>
-                retrospective.consumptionKind === ConsumptionKind.emotional
-            )}
-            onClickRetrospectiveDetail={() => {
-              setConsumptionKind(ConsumptionKind.emotional);
-              setOpen(true);
-            }}
-          />
-          <div className='h-2 bg-[#F5F3F0] shrink-0' />
-          <RetrospectiveCard
-            consumption={consumptionConscious}
-            retrospective={retrospectives.find(
-              (retrospective) =>
-                retrospective.consumptionKind === ConsumptionKind.conscious
-            )}
-            onClickRetrospectiveDetail={() => {
-              setConsumptionKind(ConsumptionKind.conscious);
-              setOpen(true);
-            }}
-          />
-          <div className='h-2 bg-[#F5F3F0] shrink-0' />
-          <RetrospectiveCard
-            consumption={consumptionEssential}
-            retrospective={retrospectives.find(
-              (retrospective) =>
-                retrospective.consumptionKind === ConsumptionKind.essential
-            )}
-            onClickRetrospectiveDetail={() => {
-              setConsumptionKind(ConsumptionKind.essential);
-              setOpen(true);
-            }}
-          />
-          <div className='h-4 w-full bg-white shrink-0' />
-        </>
-      )}
-    </div>
+            <div className='h-2 bg-[#F5F3F0] shrink-0' />
+            <RetrospectiveCard
+              consumption={consumptionConscious}
+              retrospective={retrospectives.find(
+                (retrospective) =>
+                  retrospective.consumptionKind === ConsumptionKind.conscious
+              )}
+              onClickRetrospectiveDetail={() => {
+                setConsumptionKind(ConsumptionKind.conscious);
+                setOpen(true);
+              }}
+            />
+            <div className='h-2 bg-[#F5F3F0] shrink-0' />
+            <RetrospectiveCard
+              consumption={consumptionEssential}
+              retrospective={retrospectives.find(
+                (retrospective) =>
+                  retrospective.consumptionKind === ConsumptionKind.essential
+              )}
+              onClickRetrospectiveDetail={() => {
+                setConsumptionKind(ConsumptionKind.essential);
+                setOpen(true);
+              }}
+            />
+            <div className='h-4 w-full bg-white shrink-0' />
+          </>
+        )}
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
- 이유: 회고 뷰에서 회고 디테일 페이지(Popover) 렌더링을 최상위 부모에서 주지 않았음

---

## 수정 전 
![image](https://github.com/user-attachments/assets/edf35c9c-ddd1-4deb-8a63-1cd842bff9ea)

---

## 수정 후
![image](https://github.com/user-attachments/assets/6d9feafb-21fc-4c09-84ce-115bd15dabbc)

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 레트로스펙티브 상세 팝오버가 메인 콘텐츠 외부에서 렌더링되도록 구조를 개선하여 UI 렌더링 순서를 변경했습니다.  
  - 사용자에게 보이는 기능 및 동작에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->