### PR TITLE
지출내역 폼에서 소비 분류 선택 추가, 카테고리 선택 버튼 디자인 수정

### DIFF
--- a/src/features/expense/model/ConsumptionKind.ts
+++ b/src/features/expense/model/ConsumptionKind.ts
@@ -1,8 +1,8 @@
 export const ConsumptionKind = {
   none: 'none',
-  essential: 'essential',
-  conscious: 'conscious',
-  emotional: 'emotional',
+  essential: '필수 소비',
+  conscious: '의식적 소비',
+  emotional: '감정적 소비',
 };
 
 export type ConsumptionKind =

--- a/src/features/expense/model/ConsumptionKind.ts
+++ b/src/features/expense/model/ConsumptionKind.ts
@@ -1,8 +1,8 @@
 export const ConsumptionKind = {
   none: 'none',
-  essential: '필수 소비',
-  conscious: '의식적 소비',
-  emotional: '감정적 소비',
+  essential: 'essential',
+  conscious: 'conscious',
+  emotional: 'emotional',
 };
 
 export type ConsumptionKind =

--- a/src/features/expense/ui/ConsumptionKindDrawer/ConsumptionKindDrawer.test.tsx
+++ b/src/features/expense/ui/ConsumptionKindDrawer/ConsumptionKindDrawer.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import { describe, it, vi } from 'vitest';
 
-import ReviewExpenseDrawer, { type Props } from './ReviewExpenseDrawer';
+import ConsumptionKindDrawer, { type Props } from './ConsumptionKindDrawer';
 
 describe('ReviewExpenseDrawer', () => {
   const props: Props = {
@@ -12,7 +12,7 @@ describe('ReviewExpenseDrawer', () => {
 
   const renderElement = ({ isOpen, setConsumptionKind, onOpenChange }: Props) =>
     render(
-      <ReviewExpenseDrawer
+      <ConsumptionKindDrawer
         isOpen={isOpen}
         setConsumptionKind={setConsumptionKind}
         onOpenChange={onOpenChange}

--- a/src/features/expense/ui/ConsumptionKindDrawer/ConsumptionKindDrawer.test.tsx
+++ b/src/features/expense/ui/ConsumptionKindDrawer/ConsumptionKindDrawer.test.tsx
@@ -6,16 +6,16 @@ import ConsumptionKindDrawer, { type Props } from './ConsumptionKindDrawer';
 describe('ReviewExpenseDrawer', () => {
   const props: Props = {
     isOpen: false,
+    onClose: vi.fn(),
     setConsumptionKind: vi.fn(),
-    onOpenChange: vi.fn(),
   };
 
-  const renderElement = ({ isOpen, setConsumptionKind, onOpenChange }: Props) =>
+  const renderElement = ({ isOpen, onClose, setConsumptionKind }: Props) =>
     render(
       <ConsumptionKindDrawer
         isOpen={isOpen}
+        onClose={onClose}
         setConsumptionKind={setConsumptionKind}
-        onOpenChange={onOpenChange}
       />
     );
 

--- a/src/features/expense/ui/ConsumptionKindDrawer/ConsumptionKindDrawer.test.tsx
+++ b/src/features/expense/ui/ConsumptionKindDrawer/ConsumptionKindDrawer.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, vi } from 'vitest';
 
 import ConsumptionKindDrawer, { type Props } from './ConsumptionKindDrawer';
 
-describe('ReviewExpenseDrawer', () => {
+describe('ConsumptionKindDrawer', () => {
   const props: Props = {
     isOpen: false,
     onClose: vi.fn(),

--- a/src/features/expense/ui/ConsumptionKindDrawer/ConsumptionKindDrawer.tsx
+++ b/src/features/expense/ui/ConsumptionKindDrawer/ConsumptionKindDrawer.tsx
@@ -102,7 +102,7 @@ export interface Props {
   onOpenChange: (open: boolean) => void;
 }
 
-const ReviewExpenseDrawer: React.FC<Props> = ({
+const ConsumptionKindDrawer: React.FC<Props> = ({
   isOpen,
   setConsumptionKind,
   onOpenChange,
@@ -170,4 +170,4 @@ const ReviewExpenseDrawer: React.FC<Props> = ({
   );
 };
 
-export default ReviewExpenseDrawer;
+export default ConsumptionKindDrawer;

--- a/src/features/expense/ui/ConsumptionKindDrawer/ConsumptionKindDrawer.tsx
+++ b/src/features/expense/ui/ConsumptionKindDrawer/ConsumptionKindDrawer.tsx
@@ -98,27 +98,21 @@ const consumptions: Consumption[] = [
 
 export interface Props {
   isOpen: boolean;
+  onClose: () => void;
   setConsumptionKind: (consumptionKind: ConsumptionKind) => void;
-  onOpenChange: (open: boolean) => void;
 }
 
 const ConsumptionKindDrawer: React.FC<Props> = ({
   isOpen,
+  onClose,
   setConsumptionKind,
-  onOpenChange,
 }) => {
-  const [selectedKind, setSelectedKind] = useState<ConsumptionKind | null>(
-    null
+  const [selectedKind, setSelectedKind] = useState<ConsumptionKind>(
+    ConsumptionKind.none
   );
 
   return (
-    <Drawer
-      open={isOpen}
-      onOpenChange={onOpenChange}
-      onClose={() => {
-        setSelectedKind(null);
-      }}
-    >
+    <Drawer open={isOpen} onClose={onClose}>
       <DrawerContent className='px-5 py-6 rounded-t-[20px] bg-white'>
         <DrawerHeader className='flex flex-col gap-0 p-0'>
           <div className='flex flex-row'>
@@ -152,15 +146,16 @@ const ConsumptionKindDrawer: React.FC<Props> = ({
         </div>
         <DrawerFooter className='mt-8 p-0'>
           <Button
+            type='button'
             className='h-13 rounded-full text-white bg-[#222] font-semibold disabled:bg-[#CCC]'
             onClick={() => {
-              if (selectedKind) {
+              if (selectedKind !== ConsumptionKind.none) {
                 setConsumptionKind(selectedKind);
-                setSelectedKind(null);
-                onOpenChange(false);
+                setSelectedKind(ConsumptionKind.none);
+                onClose();
               }
             }}
-            disabled={selectedKind === null}
+            disabled={selectedKind === ConsumptionKind.none}
           >
             완료
           </Button>

--- a/src/features/expense/ui/ConsumptionKindDrawer/index.tsx
+++ b/src/features/expense/ui/ConsumptionKindDrawer/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ConsumptionKindDrawer';

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.test.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.test.tsx
@@ -65,14 +65,16 @@ describe('ExpenseForm', () => {
     });
   });
 
-  describe('submit button', () => {
-    it('renders 추가 when expense is not provided.', () => {
-      const { getByRole } = renderElement({ ...props });
-      const submitButton = getByRole('button', { name: '추가' });
-      expect(submitButton).toBeInTheDocument();
+  describe('consumptionKind', () => {
+    it('renders label.', () => {
+      const { getByLabelText } = renderElement({ ...props });
+      const label = getByLabelText('소비 분류');
+      expect(label).toBeInTheDocument();
     });
+  });
 
-    it('renders 저장 when expense is provided.', () => {
+  describe('submit button', () => {
+    it('renders 저장 text.', () => {
       const { getByRole } = renderElement({
         ...props,
       });

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -41,7 +41,8 @@ export interface ExpenseFormProps {
 }
 
 const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
-  const [reviewOpen, setReviewOpen] = useState<boolean>(false);
+  const [consumptionKindOpen, setConsumptionKindOpen] =
+    useState<boolean>(false);
   const [open, setOpen] = useState<boolean>(false);
 
   const form = useForm<Omit<Expense, 'uid'>>({
@@ -237,7 +238,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
                   type='button'
                   className='flex flex-row items-center gap-1 ml-auto'
                   onClick={() => {
-                    setReviewOpen(true);
+                    setConsumptionKindOpen(true);
                   }}
                 >
                   <span className='text-[15px] text-[#28a745]'>

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -247,15 +247,18 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
                       : consumptionKind}
                   </span>
                   <ArrowRight size={16} color='#28a745' />
-                  <ConsumptionKindDrawer
-                    isOpen={reviewOpen}
-                    onOpenChange={setReviewOpen}
-                    setConsumptionKind={(kind) => {
-                      field.onChange(kind);
-                    }}
-                  />
                 </button>
               </FormControl>
+              <ConsumptionKindDrawer
+                isOpen={consumptionKindOpen}
+                onClose={() => {
+                  setConsumptionKindOpen(false);
+                  console.log(consumptionKindOpen);
+                }}
+                setConsumptionKind={(kind) => {
+                  field.onChange(kind);
+                }}
+              />
             </FormItem>
           )}
         />

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -82,7 +82,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
     }
 
     return false;
-  }, [memo, categories, amount, consumptionKind]);
+  }, [memo, categories.length, amount, consumptionKind]);
 
   return (
     <Form {...form}>

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -8,6 +8,7 @@ import {
   EXPENSE_AMOUNT_MAX,
   EXPENSE_MEMO_MAX_LEN,
 } from '@/features/expense/consts';
+import { getConsumptionTitle } from '@/features/expense/lib/consumption';
 import { ConsumptionKind } from '@/features/expense/model/ConsumptionKind';
 import { Expense } from '@/features/expense/model/Expense';
 import CalendarDrawer from '@/features/expense/ui/CalendarDrawer';
@@ -249,7 +250,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
                   <span className='text-[15px] text-[#28a745]'>
                     {consumptionKind === ConsumptionKind.none
                       ? '소비를 리뷰하세요'
-                      : consumptionKind}
+                      : getConsumptionTitle(consumptionKind)}
                   </span>
                   <ArrowRight size={16} color='#28a745' />
                 </button>

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -97,7 +97,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
         />
       )}
       <form
-        className='flex flex-col gap-8 h-screen pt-6 px-5'
+        className='flex flex-col gap-6 h-screen pt-6 px-5'
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         onSubmit={handleSubmit(onSubmit)}
       >

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -51,7 +51,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
       memo: expense.memo,
       categories: expense.categories,
       amount: expense.amount === 0 ? undefined : expense.amount,
-      consumptionKind: ConsumptionKind.none,
+      consumptionKind: expense.consumptionKind ?? ConsumptionKind.none,
     },
     mode: 'onChange',
   });

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -11,7 +11,7 @@ import {
 import { ConsumptionKind } from '@/features/expense/model/ConsumptionKind';
 import { Expense } from '@/features/expense/model/Expense';
 import CalendarDrawer from '@/features/expense/ui/CalendarDrawer';
-import ReviewExpenseDrawer from '@/features/expense/ui/ReviewExpenseDrawer';
+import ConsumptionKindDrawer from '@/features/expense/ui/ConsumptionKindDrawer';
 import { Button, buttonVariants } from '@/shared/ui/atoms/button';
 import {
   Form,
@@ -252,7 +252,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
                       : consumptionKind}
                   </span>
                   <ArrowRight size={16} color='#28a745' />
-                  <ReviewExpenseDrawer
+                  <ConsumptionKindDrawer
                     isOpen={reviewOpen}
                     onOpenChange={setReviewOpen}
                     setConsumptionKind={(kind) => {

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -43,7 +43,7 @@ export interface ExpenseFormProps {
 const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
   const [consumptionKindOpen, setConsumptionKindOpen] =
     useState<boolean>(false);
-  const [open, setOpen] = useState<boolean>(false);
+  const [categoryOpen, setCategoryOpen] = useState<boolean>(false);
 
   const form = useForm<Omit<Expense, 'uid'>>({
     defaultValues: {
@@ -85,14 +85,14 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
 
   return (
     <Form {...form}>
-      {open && (
+      {categoryOpen && (
         <CategoriesPopoverPage
           selectedCategories={categories}
           setSelectedCategories={(values) => {
             form.setValue('categories', values);
           }}
           onClose={() => {
-            setOpen(false);
+            setCategoryOpen(false);
           }}
         />
       )}
@@ -167,17 +167,17 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
                 >
                   카테고리
                 </FormLabel>
-                <Button
+                <button
                   type='button'
                   id='categories'
                   aria-label='카테고리 설정 버튼'
                   className='rounded-full bg-[#efefef] hover:bg-accent h-[28px] w-[39px] items-center text-[13px] text-[#555] ml-auto py-1 px-2 shadow-none font-normal'
                   onClick={() => {
-                    setOpen(true);
+                    setCategoryOpen(true);
                   }}
                 >
                   설정
-                </Button>
+                </button>
               </div>
               <div className='flex flex-row gap-2 flex-wrap'>
                 {field.value.map((category) => (

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -12,7 +12,7 @@ import { ConsumptionKind } from '@/features/expense/model/ConsumptionKind';
 import { Expense } from '@/features/expense/model/Expense';
 import CalendarDrawer from '@/features/expense/ui/CalendarDrawer';
 import ConsumptionKindDrawer from '@/features/expense/ui/ConsumptionKindDrawer';
-import { Button, buttonVariants } from '@/shared/ui/atoms/button';
+import { Button } from '@/shared/ui/atoms/button';
 import {
   Form,
   FormControl,
@@ -26,14 +26,8 @@ import { cn } from '@/shared/ui/styles/utils';
 
 const CalendarDrawerTrigger = ({ date }: { date: Date }) => {
   return (
-    <div
-      className={cn(
-        buttonVariants({ variant: 'ghost' }),
-        'has-[>svg]:p-0',
-        'flex flex-row items-center h-4 w-auto ml-auto p-0'
-      )}
-    >
-      <span className='inline-flex items-center mr-1 text-[15px] font-normal text-[#28a745] relative top-[1px]'>
+    <div className='flex flex-row items-center gap-1 ml-auto'>
+      <span className='text-[15px] text-[#28a745]'>
         {`${date.getFullYear().toString()}년 ${(date.getMonth() + 1).toString()}월 ${date.getDate().toString()}일`}
       </span>
       <ArrowRight size={16} color='#28a745' />
@@ -241,12 +235,12 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
               <FormControl>
                 <button
                   type='button'
-                  className='flex flex-row items-center h-4 w-auto ml-auto p-0'
+                  className='flex flex-row items-center gap-1 ml-auto'
                   onClick={() => {
                     setReviewOpen(true);
                   }}
                 >
-                  <span className='text-[15px] text-[#28a745] mr-[4px]'>
+                  <span className='text-[15px] text-[#28a745]'>
                     {consumptionKind === ConsumptionKind.none
                       ? '소비를 리뷰하세요'
                       : consumptionKind}
@@ -267,7 +261,6 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
         <div className='fixed bottom-0 left-0 right-0 w-full min-w-[360px] max-w-[430px] mx-auto px-5 py-4 bg-white border-t border-gray-100'>
           <Button
             type='submit'
-            // origin: mt-auto
             className='w-full h-13 text-[15px] font-semibold mt-auto rounded-full'
             disabled={disabled}
           >

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -146,7 +146,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
                 <LabeledTextarea
                   label='메모'
                   id='memo'
-                  placeholder={`어디서, 무엇을 결제하셨나요?\r\n그때 기분은 어땠나요?`}
+                  placeholder={`어디서, 무엇을 결제하셨나요?\r\n그때 기분과 소비 이유도 같이 기록해요.`}
                   value={field.value}
                   onChange={(e) => {
                     if (e.length <= EXPENSE_MEMO_MAX_LEN) {

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -258,7 +258,6 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
                 isOpen={consumptionKindOpen}
                 onClose={() => {
                   setConsumptionKindOpen(false);
-                  console.log(consumptionKindOpen);
                 }}
                 setConsumptionKind={(kind) => {
                   field.onChange(kind);

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -248,7 +248,8 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
                   }}
                 >
                   <span className='text-[15px] text-[#28a745]'>
-                    {consumptionKind === ConsumptionKind.none
+                    {consumptionKind === ConsumptionKind.none ||
+                    consumptionKind === undefined
                       ? '소비를 리뷰하세요'
                       : getConsumptionTitle(consumptionKind)}
                   </span>

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -159,7 +159,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
           control={form.control}
           name='categories'
           render={({ field }) => (
-            <FormItem>
+            <FormItem className='flex flex-col gap-4'>
               <div className='flex flex-row items-center'>
                 <FormLabel
                   htmlFor='categories'
@@ -171,12 +171,13 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
                   type='button'
                   id='categories'
                   aria-label='카테고리 설정 버튼'
-                  className='rounded-full bg-[#efefef] hover:bg-accent h-[28px] w-[39px] items-center text-[13px] text-[#555] ml-auto py-1 px-2 shadow-none font-normal'
+                  className='flex flex-row items-center gap-1 ml-auto'
                   onClick={() => {
                     setCategoryOpen(true);
                   }}
                 >
-                  설정
+                  <span className='text-[15px] text-[#28a745]'>설정</span>
+                  <ArrowRight size={16} color='#28a745' />
                 </button>
               </div>
               <div className='flex flex-row gap-2 flex-wrap'>

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -108,7 +108,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
             <FormItem className='flex flex-row'>
               <FormLabel
                 htmlFor='date'
-                className='text-[15px] font-semibold text-[#222] p-0'
+                className='text-[15px] font-semibold text-[#222]'
               >
                 날짜
               </FormLabel>
@@ -196,7 +196,9 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
           name='amount'
           render={({ field }) => (
             <FormItem className='flex flex-col gap-2'>
-              <FormLabel className='text-[15px] font-semibold'>금액</FormLabel>
+              <FormLabel className='text-[15px] font-semibold text-[#222]'>
+                금액
+              </FormLabel>
               <FormControl>
                 <NumericFormat
                   inputMode='numeric'
@@ -232,7 +234,9 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
           name='consumptionKind'
           render={({ field }) => (
             <FormItem className='flex flex-row'>
-              <FormLabel>소비 분류</FormLabel>
+              <FormLabel className='text-[15px] font-semibold text-[#222]'>
+                소비 분류
+              </FormLabel>
               <FormControl>
                 <button
                   type='button'

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -170,7 +170,6 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
                 </FormLabel>
                 <button
                   type='button'
-                  id='categories'
                   aria-label='카테고리 설정 버튼'
                   className='flex flex-row items-center gap-1 ml-auto'
                   onClick={() => {

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -246,7 +246,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
                     setReviewOpen(true);
                   }}
                 >
-                  <span>
+                  <span className='text-[15px] text-[#28a745] mr-[4px]'>
                     {consumptionKind === ConsumptionKind.none
                       ? '소비를 리뷰하세요'
                       : consumptionKind}

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -170,6 +170,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
                 </FormLabel>
                 <button
                   type='button'
+                  id='categories'
                   aria-label='카테고리 설정 버튼'
                   className='flex flex-row items-center gap-1 ml-auto'
                   onClick={() => {

--- a/src/features/expense/ui/ReviewExpenseDrawer/index.tsx
+++ b/src/features/expense/ui/ReviewExpenseDrawer/index.tsx
@@ -1,1 +1,0 @@
-export { default } from './ReviewExpenseDrawer';

--- a/src/shared/ui/LabeledTextarea/LabeledTextarea.tsx
+++ b/src/shared/ui/LabeledTextarea/LabeledTextarea.tsx
@@ -39,7 +39,8 @@ const LabeledTextarea: React.FC<LabeledTextareaProps> = ({
         }}
         wrap='hard'
         className={cn(
-          'w-full max-w-full break-all h-38 rounded-xl border text-left leading-normal text-[15px] p-5',
+          'h-30 w-full max-w-full p-4 rounded-xl border',
+          'text-left leading-normal text-[15px] break-all',
           'placeholder:whitespace-pre-line placeholder:text-[#999999] shadow-none',
           'focus-visible:border-[#555555]',
           state === 'default' && 'border-[#cccccc]',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 소비 유형 선택을 위한 드로어(ConsumptionKindDrawer) UI가 도입되었습니다.
  - 지출 입력 폼에 소비 유형 필드가 추가되어, 소비 목적을 기록할 수 있습니다.

- **버그 수정**
  - 제출 버튼이 소비 유형 미선택 시 비활성화되어, 필수 입력값 누락을 방지합니다.

- **스타일**
  - 메모 입력란의 높이 및 패딩이 조정되어 가독성이 향상되었습니다.
  - 카테고리 및 캘린더 트리거 버튼 스타일이 개선되었습니다.

- **기타**
  - 일부 컴포넌트 명칭이 변경되고, 관련 파일 구조가 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->