### PR TITLE
fix: add temporary updateExpense with consumption kind after addExpense

### DIFF
--- a/src/pages/expenses.new.index.tsx
+++ b/src/pages/expenses.new.index.tsx
@@ -2,7 +2,11 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { toast } from 'sonner';
 
 import AuthGuard from '@/features/auth/ui/AuthGuard';
-import { useAddExpense } from '@/features/expense/api/useExpenseQuery';
+import {
+  useAddExpense,
+  useUpdateExpense,
+} from '@/features/expense/api/useExpenseQuery';
+import { ConsumptionKind } from '@/features/expense/model/ConsumptionKind';
 import { Expense } from '@/features/expense/model/Expense';
 import ExpenseForm from '@/features/expense/ui/ExpenseForm';
 import SubPageHeader from '@/shared/ui/SubPageHeader';
@@ -18,21 +22,36 @@ export const Route = createFileRoute('/expenses/new/')({
 export function RouteComponent() {
   const navigate = useNavigate();
   const addExpense = useAddExpense();
+  const updateExpense = useUpdateExpense();
 
   const initialExpense: Omit<Expense, 'uid'> = {
     date: new Date(),
     memo: '',
     categories: [],
     amount: 0,
+    consumptionKind: ConsumptionKind.none,
   };
 
   const handleSubmit = (expense: Omit<Expense, 'uid'>) => {
+    const consumptionKind = expense.consumptionKind ?? ConsumptionKind.none;
+
     addExpense.mutate(
       { ...expense },
       {
-        onSuccess: () => {
-          toast.success('지출내역을 추가했어요.');
-          void navigate({ to: '/expenses' });
+        onSuccess: (data) => {
+          // todo: remove this
+          updateExpense.mutate(
+            { ...expense, uid: data.uid, consumptionKind },
+            {
+              onSuccess: () => {
+                toast.success('지출내역을 추가했어요.');
+                void navigate({ to: '/expenses' });
+              },
+              onError: () => {
+                toast.error('지출내역을 추가하는데 실패했어요.');
+              },
+            }
+          );
         },
         onError: () => {
           toast.error('지출내역을 추가하는데 실패했어요.');

--- a/src/pages/expenses.new.index.tsx
+++ b/src/pages/expenses.new.index.tsx
@@ -48,7 +48,9 @@ export function RouteComponent() {
                 void navigate({ to: '/expenses' });
               },
               onError: () => {
-                toast.error('지출내역을 추가하는데 실패했어요.');
+                toast.error(
+                  '지출내역 업데이트에 실패했어요. 소비 종류가 기본값으로 설정되었습니다.'
+                );
               },
             }
           );


### PR DESCRIPTION
addExpense시 consumption_kind가 기본으로 none으로 내려오고 있어, addExpense 이후 updateExpense를 호출한다. 지출내역 생성 직후 소비 분류를 선택해서 임시로 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **신규 기능**
  - 지출 추가 시 소비 유형(consumptionKind)을 함께 설정할 수 있도록 개선되었습니다.
- **버그 수정**
  - 지출 등록 후 소비 유형이 즉시 반영되지 않는 문제를 해결하였습니다.
- **알림**
  - 지출 및 소비 유형 업데이트 성공 또는 실패 시 알림 메시지가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->