### PR TITLE
기능 QA 3.0 failed 대응

### DIFF
--- a/src/features/expense/ui/ConsumptionKindDrawer/ConsumptionKindDrawer.test.tsx
+++ b/src/features/expense/ui/ConsumptionKindDrawer/ConsumptionKindDrawer.test.tsx
@@ -1,20 +1,29 @@
 import { render } from '@testing-library/react';
 import { describe, it, vi } from 'vitest';
 
+import { ConsumptionKind } from '@/features/expense/model/ConsumptionKind';
+
 import ConsumptionKindDrawer, { type Props } from './ConsumptionKindDrawer';
 
 describe('ConsumptionKindDrawer', () => {
   const props: Props = {
     isOpen: false,
     onClose: vi.fn(),
+    consumptionKind: ConsumptionKind.none,
     setConsumptionKind: vi.fn(),
   };
 
-  const renderElement = ({ isOpen, onClose, setConsumptionKind }: Props) =>
+  const renderElement = ({
+    isOpen,
+    onClose,
+    consumptionKind,
+    setConsumptionKind,
+  }: Props) =>
     render(
       <ConsumptionKindDrawer
         isOpen={isOpen}
         onClose={onClose}
+        consumptionKind={consumptionKind}
         setConsumptionKind={setConsumptionKind}
       />
     );

--- a/src/features/expense/ui/ConsumptionKindDrawer/ConsumptionKindDrawer.tsx
+++ b/src/features/expense/ui/ConsumptionKindDrawer/ConsumptionKindDrawer.tsx
@@ -99,17 +99,18 @@ const consumptions: Consumption[] = [
 export interface Props {
   isOpen: boolean;
   onClose: () => void;
+  consumptionKind: ConsumptionKind;
   setConsumptionKind: (consumptionKind: ConsumptionKind) => void;
 }
 
 const ConsumptionKindDrawer: React.FC<Props> = ({
   isOpen,
   onClose,
+  consumptionKind,
   setConsumptionKind,
 }) => {
-  const [selectedKind, setSelectedKind] = useState<ConsumptionKind>(
-    ConsumptionKind.none
-  );
+  const [selectedKind, setSelectedKind] =
+    useState<ConsumptionKind>(consumptionKind);
 
   return (
     <Drawer open={isOpen} onClose={onClose}>

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -257,6 +257,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
                 onClose={() => {
                   setConsumptionKindOpen(false);
                 }}
+                consumptionKind={consumptionKind ?? ConsumptionKind.none}
                 setConsumptionKind={(kind) => {
                   field.onChange(kind);
                 }}

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -77,12 +77,8 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
       return true;
     }
 
-    if (!consumptionKind || consumptionKind === ConsumptionKind.none) {
-      return true;
-    }
-
     return false;
-  }, [memo, categories.length, amount, consumptionKind]);
+  }, [memo, categories.length, amount]);
 
   return (
     <Form {...form}>


### PR DESCRIPTION
- ConsumptionKindDrawer에서 consumptionKind props 추가
- ExpenseForm에서 ConsumptionKind가 필수값이 아니게 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - ConsumptionKindDrawer가 외부에서 전달된 소비 유형(consumptionKind) 값을 올바르게 반영하도록 개선되었습니다.
  - ExpenseForm에서 소비 유형이 'none'이거나 비어 있을 때 폼이 비활성화되지 않도록 수정되었습니다.

- **테스트**
  - ConsumptionKindDrawer 컴포넌트 테스트가 consumptionKind 속성을 명확히 포함하도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->