### PR TITLE
safe-area용 페이지 하단 버튼 수정

### DIFF
--- a/src/features/category/ui/CategoriesPopoverPage.tsx
+++ b/src/features/category/ui/CategoriesPopoverPage.tsx
@@ -187,26 +187,24 @@ export default function CategoriesPopoverPage({
             )}
           </div>
         </div>
-        <div className='fixed bottom-0 left-0 right-0 w-full min-w-[360px] max-w-[430px] mx-auto px-5 py-4 bg-white border-t border-gray-100'>
-          <Button
-            className='h-13 rounded-full text-[15px] w-full'
-            onClick={() => {
-              setSelectedCategories(
-                categories
-                  ? categories.filter((c) =>
-                      values.find((value) => value === c.name)
-                    )
-                  : []
-              );
-              onClose();
-            }}
-            disabled={
-              !categories || categories.length === 0 || values.length === 0
-            }
-          >
-            {submitButtonText}
-          </Button>
-        </div>
+        <Button
+          className='h-13 rounded-full text-[15px] w-full mt-auto mb-8 disabled:bg-[#ccc] bg-[#222]'
+          onClick={() => {
+            setSelectedCategories(
+              categories
+                ? categories.filter((c) =>
+                    values.find((value) => value === c.name)
+                  )
+                : []
+            );
+            onClose();
+          }}
+          disabled={
+            !categories || categories.length === 0 || values.length === 0
+          }
+        >
+          {submitButtonText}
+        </Button>
       </Layout>
     </div>
   );

--- a/src/features/category/ui/CategoriesPopoverPage.tsx
+++ b/src/features/category/ui/CategoriesPopoverPage.tsx
@@ -187,8 +187,8 @@ export default function CategoriesPopoverPage({
             )}
           </div>
         </div>
-        <Button
-          className='h-13 rounded-full text-[15px] w-full mt-auto mb-8 disabled:bg-[#ccc] bg-[#222] px-5'
+        <button
+          className='h-13 rounded-full text-[15px] text-white mt-auto mb-8 mx-5 disabled:bg-[#ccc] bg-[#222]'
           onClick={() => {
             setSelectedCategories(
               categories
@@ -204,7 +204,7 @@ export default function CategoriesPopoverPage({
           }
         >
           {submitButtonText}
-        </Button>
+        </button>
       </Layout>
     </div>
   );

--- a/src/features/category/ui/CategoriesPopoverPage.tsx
+++ b/src/features/category/ui/CategoriesPopoverPage.tsx
@@ -188,7 +188,7 @@ export default function CategoriesPopoverPage({
           </div>
         </div>
         <Button
-          className='h-13 rounded-full text-[15px] w-full mt-auto mb-8 disabled:bg-[#ccc] bg-[#222]'
+          className='h-13 rounded-full text-[15px] w-full mt-auto mb-8 disabled:bg-[#ccc] bg-[#222] px-5'
           onClick={() => {
             setSelectedCategories(
               categories

--- a/src/features/category/ui/CategoryPopoverPage.tsx
+++ b/src/features/category/ui/CategoryPopoverPage.tsx
@@ -138,49 +138,49 @@ export default function CategoryPopoverPage({
                 </FormItem>
               )}
             />
-            <div className='flex flex-row w-full gap-2 mt-auto'>
-              <Drawer>
-                <DrawerTrigger
-                  type='button'
-                  className={cn(
-                    buttonVariants({ variant: 'default' }),
-                    'flex-1 rounded-full h-13 text-[15px] text-[#555555] bg-[#efefef] hover:bg-[#efefef]/80 shadow-none'
-                  )}
-                >
-                  삭제
-                </DrawerTrigger>
-                <DrawerContent className='py-8 px-5 !rounded-t-[20px]'>
-                  <DrawerHeader className='p-0'>
-                    <DrawerTitle className='text-[19px] text-[#222] font-semibold'>
-                      카테고리를 삭제할까요?
-                    </DrawerTitle>
-                    <DrawerDescription className='text-15px text-[#555]'>
-                      카테고리를 삭제하면, 연결된 지출 내역의 {category.name}{' '}
-                      태그도 함께 삭제돼요.
-                    </DrawerDescription>
-                  </DrawerHeader>
-                  <DrawerFooter className='p-0 mt-8 gap-0'>
-                    <Button className='h-13 rounded-full' onClick={onDelete}>
-                      삭제
-                    </Button>
-                    <DrawerClose asChild>
-                      <button className='w-auto h-auto mx-auto mt-[25px] text-[15px] text-[#555] font-semibold'>
-                        취소
-                      </button>
-                    </DrawerClose>
-                  </DrawerFooter>
-                </DrawerContent>
-              </Drawer>
-              <Button
-                type='submit'
-                className='flex-1 rounded-full h-13 text-[15px] text-white bg-[#222] hover:bg-[#222]/80'
-                disabled={disabled}
-              >
-                저장
-              </Button>
-            </div>
           </form>
         </Form>
+        <div className='flex flex-row w-full gap-2 mt-auto px-5 mb-8'>
+          <Drawer>
+            <DrawerTrigger
+              type='button'
+              className={cn(
+                buttonVariants({ variant: 'default' }),
+                'flex-1 rounded-full h-13 text-[15px] text-[#555555] bg-[#efefef] hover:bg-[#efefef]/80 shadow-none'
+              )}
+            >
+              삭제
+            </DrawerTrigger>
+            <DrawerContent className='py-8 px-5 !rounded-t-[20px]'>
+              <DrawerHeader className='p-0'>
+                <DrawerTitle className='text-[19px] text-[#222] font-semibold'>
+                  카테고리를 삭제할까요?
+                </DrawerTitle>
+                <DrawerDescription className='text-15px text-[#555]'>
+                  카테고리를 삭제하면, 연결된 지출 내역의 {category.name} 태그도
+                  함께 삭제돼요.
+                </DrawerDescription>
+              </DrawerHeader>
+              <DrawerFooter className='p-0 mt-8 gap-0'>
+                <Button className='h-13 rounded-full' onClick={onDelete}>
+                  삭제
+                </Button>
+                <DrawerClose asChild>
+                  <button className='w-auto h-auto mx-auto mt-[25px] text-[15px] text-[#555] font-semibold'>
+                    취소
+                  </button>
+                </DrawerClose>
+              </DrawerFooter>
+            </DrawerContent>
+          </Drawer>
+          <Button
+            type='submit'
+            className='flex-1 rounded-full h-13 text-[15px] text-white bg-[#222] hover:bg-[#222]/80'
+            disabled={disabled}
+          >
+            저장
+          </Button>
+        </div>
       </Layout>
     </div>
   );

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -93,7 +93,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
         />
       )}
       <form
-        className='flex flex-col gap-6 h-screen pt-6 px-5'
+        className='flex-1 flex flex-col gap-6 h-screen pt-6 px-5'
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         onSubmit={handleSubmit(onSubmit)}
       >

--- a/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
+++ b/src/features/expense/ui/ExpenseForm/ExpenseForm.tsx
@@ -13,7 +13,6 @@ import { ConsumptionKind } from '@/features/expense/model/ConsumptionKind';
 import { Expense } from '@/features/expense/model/Expense';
 import CalendarDrawer from '@/features/expense/ui/CalendarDrawer';
 import ConsumptionKindDrawer from '@/features/expense/ui/ConsumptionKindDrawer';
-import { Button } from '@/shared/ui/atoms/button';
 import {
   Form,
   FormControl,
@@ -265,15 +264,13 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onSubmit }) => {
             </FormItem>
           )}
         />
-        <div className='fixed bottom-0 left-0 right-0 w-full min-w-[360px] max-w-[430px] mx-auto px-5 py-4 bg-white border-t border-gray-100'>
-          <Button
-            type='submit'
-            className='w-full h-13 text-[15px] font-semibold mt-auto rounded-full'
-            disabled={disabled}
-          >
-            저장
-          </Button>
-        </div>
+        <button
+          type='submit'
+          className='w-full h-13 text-[15px] text-white font-semibold mt-auto mb-8 rounded-full disabled:bg-[#ccc] bg-[#222]'
+          disabled={disabled}
+        >
+          저장
+        </button>
       </form>
     </Form>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 페이지 하단 버튼의 고정 위치 및 테두리 스타일이 제거되고, 버튼이 자연스러운 여백과 색상으로 변경되었습니다.
  - 카테고리 및 지출 폼의 버튼과 컨테이너 스타일이 개선되어 더 일관된 사용자 경험을 제공합니다.
  - 드로어 내 설명 텍스트의 줄바꿈이 조정되어 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->